### PR TITLE
Add the very basic skeleton where the Python spec will go.

### DIFF
--- a/python-spec/.gitignore
+++ b/python-spec/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__
+**/*.egg-info

--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build_backend = "setuptools.build_meta"
+
+[project]
+name = "somabase"
+description = "Python-language API specification and base utilities for implementation of the SOMA system."
+version = "0.0.0"

--- a/python-spec/setup.py
+++ b/python-spec/setup.py
@@ -1,0 +1,3 @@
+"""Degenerate setup.py so you can ``pip install -e .`` if you want."""
+import setuptools
+setuptools.setup()

--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -1,0 +1,1 @@
+"""Module base for the Python reference specification of SOMA."""


### PR DESCRIPTION
This sets up the infrastructure for where we can put the base classes and whatever other Python stuff we need as we develop the SOMA spec. It's about the simplest possible Python project with the minimal amount of needed stuff.

---

I’m not too attached to the name, just that `somabase` was my best idea since `soma` and `singlecell` are both already taken.