### PR TITLE
Add the basic SOMA Object and Collection types.

### DIFF
--- a/python-spec/src/somabase/base.py
+++ b/python-spec/src/somabase/base.py
@@ -1,0 +1,27 @@
+"""The most fundamental types used by the SOMA project."""
+
+from typing import MutableMapping, TypeVar
+
+
+class SOMAObject:
+    """A sentinel interface indicating that this type is a SOMA object."""
+
+    __slots__ = ()
+
+    # TODO: Consider if there are any more fundamental behaviors that should be
+    # pushed down to the SOMAObject level.
+
+
+_ST = TypeVar("_ST", bound=SOMAObject)
+"""Generic type variable for any SOMA object."""
+
+
+class Collection(SOMAObject, MutableMapping[str, _ST]):
+    """A generic string-keyed collection of :class:`SOMAObject`s.
+
+    The generic type specifies what type the Collection may contain. At its
+    most generic, a Collection may contain any SOMA object, but a subclass
+    may specify that it is a Collection of a specific type of SOMA object.
+    """
+
+    __slots__ = ()


### PR DESCRIPTION
These are the most core types in the spec, what we need to build everything else.

---

Figure I’ve got to start somewhere so it might as well be here. This is deceptively simple but there are a few decisions we’ll be making here that set some directions.

My biggest question here is about naming:

My default strategy is to name most things without the `SOMA` prefix on front, because they can be accessed by users as `somabase.Whatever`, and otherwise we have a bunch of `somabase.SOMAThingOne` and `somabase.SOMAThingTwo` running around, where we already know things belong to SOMA. This preference is influenced by my past use of the [Google Python style guide](https://google.github.io/styleguide/pyguide.html#22-imports), which mandates importing only modules, not things within modules, so names will always naturally have a prefix when they are used.

However, I can see the rationale behind including `SOMA` in the class names. However, in this case we already have `SOMAObject`, because otherwise there is `object` and `Object` and even though that name would be used bare only within the namespace I don’t like the potential confusion. If we expect implementors to import things using `from somabase import X`, then calling classes `SOMAWhatever` does make sense.

I have no strong attachment to either way.

Also let me know about a good default set of reviewers—I've picked you two (Bruce and John) just because I've been working with you most closely thus far.

---

FYI: @ambrosejcarr 
