### PR TITLE
Add concrete classes and enums for options.

### DIFF
--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -7,6 +7,8 @@ name = "somabase"
 description = "Python-language API specification and base utilities for implementation of the SOMA system."
 version = "0.0.0"
 readme = "./README.md"
+dependencies = ["attrs>=22.1"]
+requires-python = "~=3.7"
 
 [project.optional-dependencies]
 dev = ["black", "isort"]

--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -20,5 +20,4 @@ __all__ = (
 
     "IOfN",
     "BatchSize",
-    "BatchFormat",
 )

--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -3,3 +3,22 @@
 Types will be defined in their own modules and then imported here for a single
 unified namespace.
 """
+
+from somabase import base
+from somabase import options
+
+SOMAObject = base.SOMAObject
+Collection = base.Collection
+
+IOfN = options.IOfN
+BatchSize = options.BatchSize
+BatchFormat = options.BatchFormat
+
+__all__ = (
+    "SOMAObject",
+    "Collection",
+
+    "IOfN",
+    "BatchSize",
+    "BatchFormat",
+)

--- a/python-spec/src/somabase/options.py
+++ b/python-spec/src/somabase/options.py
@@ -1,0 +1,95 @@
+"""Enums and other types used as options across methods of many types.
+
+These types are *concrete* and should be accepted as inputs
+"""
+
+import enum
+from typing import Optional
+
+import attrs
+
+
+@attrs.define(frozen=True)
+class IOfN:
+    """Specifies that a read should return partition ``i`` out of ``n`` total.
+
+    For a read operation that returns ``n`` partitions, the read operation will
+    return the ``i``th partition (zero-indexed) out of ``n`` partitions of
+    approximately equal size.
+    """
+    __slots__ = ()
+
+    i: int = attrs.field()
+    """Which partition to return (zero-indexed)."""
+    n: int = attrs.field()
+    """How many partitions there will be."""
+
+    @i.validator
+    def _validate(self, _, __):
+        del _, __  # Unused.
+        if not 0 <= self.i < self.n:
+            raise ValueError(
+                f"Partition index {self.i} must be in the range [0, {self.n})"
+            )
+
+
+@attrs.define(frozen=True)
+class BatchSize:
+    """Specifies the size of a batch that should be returned from reads.
+
+    Read operations on foundational types return an iterator over "batches" of
+    data, enabling processing of larger-than-core datasets. This class allows
+    you to control what the size of those batches is.
+
+    If none of these options are set, a "reasonable" batch size is determined
+    automatically.
+
+    For example::
+
+        BatchSize(count=100)
+        # Will return batches of 100 elements.
+
+        BatchSize(bytes=1024 ** 2)
+        # Will return batches of up to 1 MB.
+
+        BatchSize()
+        # Will return automatically-sized batches.
+    """
+    __slots__ = ()
+
+    count: Optional[int] = attrs.field(default=None)
+    """``arrow.Table``s with this number of rows will be returned."""
+    bytes: Optional[int] = attrs.field(default=None)
+    """Data of up to this size in bytes will be returned."""
+
+    @count.validator
+    @bytes.validator
+    def _validate(self, attr: attrs.Attribute, value):
+        if not value:
+            return  # None (or 0, which we treat equivalently) is always valid.
+        if value < 0:
+            raise ValueError(f"If set, '{attr.name}' must be positive")
+        if self.count and self.bytes:
+            raise ValueError("Either 'count' or 'bytes' may be set, not both")
+
+
+class BatchFormat(enum.Enum):
+    """The format that will be returned from an array read operation."""
+    DENSE = "dense"
+    """Returns the coordinates of the slice and a :class:`pyarrow.Tensor`."""
+    COO = "coo"
+    """Returns a :class:`pyarrow.SparseCOOTensor`."""
+    CSC = "csc"
+    """Returns a :class:`pyarrow.SparseCSCMatrix`."""
+    CSR = "csr"
+    """Returns a :class:`pyarrow.SparseCSRMatrix`."""
+    RECORD_BATCH = "record-batch"
+    """Returns a :class:`pyarrow.RecordBatch`.
+
+    The returned data contains COO-encoded coordinates and values.
+    """
+    TABLE = "table"
+    """Returns a :class:`pyarrow.Table`.
+
+    The returned data contains COO-encoded coordinates and values.
+    """

--- a/python-spec/src/somabase/options.py
+++ b/python-spec/src/somabase/options.py
@@ -1,9 +1,9 @@
 """Enums and other types used as options across methods of many types.
 
-These types are *concrete* and should be accepted as inputs
+These types are *concrete* and should be used as-is as inputs to the various
+SOMA types that require them, not reimplemented by the implementing package.
 """
 
-import enum
 from typing import Optional
 
 import attrs
@@ -71,25 +71,3 @@ class BatchSize:
             raise ValueError(f"If set, '{attr.name}' must be positive")
         if self.count and self.bytes:
             raise ValueError("Either 'count' or 'bytes' may be set, not both")
-
-
-class BatchFormat(enum.Enum):
-    """The format that will be returned from an array read operation."""
-    DENSE = "dense"
-    """Returns the coordinates of the slice and a :class:`pyarrow.Tensor`."""
-    COO = "coo"
-    """Returns a :class:`pyarrow.SparseCOOTensor`."""
-    CSC = "csc"
-    """Returns a :class:`pyarrow.SparseCSCMatrix`."""
-    CSR = "csr"
-    """Returns a :class:`pyarrow.SparseCSRMatrix`."""
-    RECORD_BATCH = "record-batch"
-    """Returns a :class:`pyarrow.RecordBatch`.
-
-    The returned data contains COO-encoded coordinates and values.
-    """
-    TABLE = "table"
-    """Returns a :class:`pyarrow.Table`.
-
-    The returned data contains COO-encoded coordinates and values.
-    """


### PR DESCRIPTION
Adds the "common interfaces" `IOfN`, `BatchSize`, and `BatchFormat`. These classes are the exact values that implementations will use, i.e. an implementation of the SOMA API will not implement its own `IOfN` or any of these other “option” types.

These types are implemented using the `attrs` package, essentially an enhanced version of the built-in `dataclasses` package. It is very lightweight and already extensively used within the Python ecosystem so it will not add much (if anything) to the size of a typical installed environment.

---

I started on the API structure for the various NDArray types and found that we needed some options before then.

The major decision here was the way I chose to implement `BatchSize`. Instead of e.g. two different types (like maybe `CountBatch(n)` and `BytesBatch(size)`) I think a single class is a bit more convenient for authors. If for some reason in the future we have a different type of batch size that has its own complex setup, the type itself can always be renamed or otherwise refactored and `BatchSize` can remain a factory function for compatibility.

An **open question**: For the `DENSE` type, what are the details of the “coordinates of the slice (e.g. origin, shape) and an Arrow Tensor containing slice values”?

(I would be inclined to specify that it should return data as a `namedtuple` (not an attrs class, so that users who want to just unpack it like `coords, tensor = some_call_which_returns_dense(...)`. But what would those elements be?)