### PR TITLE
incorporate discussion from 20221007 design review meeting

### DIFF
--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -68,7 +68,7 @@ Numeric index types (eg, offset indexing into dense arrays) are specified with `
 
 SOMA is intended to be strongly typed. With one exception noted below, all requests for a given Arrow type must be fulfilled or generate an error based upon the capabilities of the underlying storage system. Silently casting to a less capable type (eg, float64 to float32) is _not_ permitted. All operations specifying or introspecting the type system must be self-consistent, eg, if object `create` accepts a given Arrow type or schema, the `get schema` operation must return the same types.
 
-SOMA _does_ permit one form of type promotion - variable length types (`sting`, `binary`) may be promoted to their 64-bit variants (`large_string`, `large_binary`) at the time of object creation. However, this promotion must be explicit and visible to the API user via the `get schema` operation.
+SOMA _does_ permit one form of type promotion - variable length types (`string`, `binary`) may be promoted to their 64-bit variants (`large_string`, `large_binary`) at the time of object creation. However, this promotion must be explicit and visible to the API user via the `get schema` operation.
 
 SOMA places no constraints on the underlying types used by the storage system, as long as the API-level representation is consistent across operations, and the supported types full match the Arrow definition of their type semantics.
 

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -310,7 +310,7 @@ read(
 Parameters:
 
 - slices - the rows to read. Defaults to 'all'. Rows are addressable with a row offset (uint), a row-offset range (slice), an Arrow array or chunked array of row-offsets, or a list of both offsets and slices.
-- column_names - the named columns to read and return. Defaults to all. System-defined columns (`soma_rowid` and `soma_joinid`) may be included in this list.
+- column_names - the named columns to read and return. Defaults to all, including system-defined columns (`soma_rowid` and `soma_joinid`).
 - batch_size - a [`SOMABatchSize`](#SOMABatchSize), indicating the size of each "batch" returned by the read iterator. Defaults to `auto`.
 - partition - an optional [`SOMAReadPartitions`](#SOMAReadPartitions) to partition read operations.
 - result_order - order of read results. If dataframe is indexed, can be one of row-major, column-major or unordered. If dataframe is non-indexed, can be one of rowid-ordered or unordered.
@@ -404,7 +404,7 @@ read(
 Parameters:
 
 - ids - the rows to read. Defaults to 'all'. Coordinates for each dimension may be specified by value, a value range (slice), an Arrow array of values, or a list of both.
-- column_names - the named columns to read and return. Defaults to all. System-defined columns (`soma_joinid`) may be included in this list.
+- column_names - the named columns to read and return. Defaults to all, including system-defined columns (`soma_joinid`).
 - batch_size - a [`SOMABatchSize`](#SOMABatchSize), indicating the size of each "batch" returned by the read iterator. Defaults to `auto`.
 - partition - an optional [`SOMAReadPartitions`](#SOMAReadPartitions) to partition read operations.
 - result_order - order of read results. If dataframe is indexed, can be one of row-major, col-major or unordered. If dataframe is non-indexed, can be one of rowid-ordered or unordered.


### PR DESCRIPTION
Changes:
* All offset types (`soma_rowid`, `soma_joinid`) changed from uint64 to positive int64.
* Remove `reshape` operation from the NdArray types.
* Clarify schema type conformance and promotion behavior, particularly with regard to Arrow's `string` and `large_string`
* NdArray COO column names - add `soma` prefix to move all names into the reserved namespace.
* Clarify explicit nature of `soma_rowid` / `soma_joinid` handling throughout.

Optional review:  @ambrosejcarr 
