### PR TITLE
python: Add basis of data storage types

### DIFF
--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -7,7 +7,7 @@ name = "somabase"
 description = "Python-language API specification and base utilities for implementation of the SOMA system."
 version = "0.0.0"
 readme = "./README.md"
-dependencies = ["attrs>=22.1"]
+dependencies = ["attrs>=22.1", "typing_extensions"]
 requires-python = "~=3.7"
 
 [project.optional-dependencies]
@@ -17,4 +17,4 @@ dev = ["black", "isort"]
 profile = "black"
 line_length = 88
 force_single_line = true
-single_line_exclusions = ["typing"]
+single_line_exclusions = ["typing", "typing_extensions"]

--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -7,7 +7,7 @@ name = "somabase"
 description = "Python-language API specification and base utilities for implementation of the SOMA system."
 version = "0.0.0"
 readme = "./README.md"
-dependencies = ["attrs>=22.1", "typing_extensions"]
+dependencies = ["attrs>=22.1", "pyarrow", "typing_extensions"]
 requires-python = "~=3.7"
 
 [project.optional-dependencies]

--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -12,7 +12,6 @@ Collection = base.Collection
 
 IOfN = options.IOfN
 BatchSize = options.BatchSize
-BatchFormat = options.BatchFormat
 
 __all__ = (
     "SOMAObject",

--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -5,10 +5,17 @@ unified namespace.
 """
 
 from somabase import base
+from somabase import data
 from somabase import options
 
 SOMAObject = base.SOMAObject
 Collection = base.Collection
+
+DataFrame = data.DataFrame
+NDArray = data.NDArray
+CoordsData = data.CoordsData
+DenseNDArray = data.DenseNDArray
+SparseNDArray = data.SparseNDArray
 
 IOfN = options.IOfN
 BatchSize = options.BatchSize
@@ -16,6 +23,11 @@ BatchSize = options.BatchSize
 __all__ = (
     "SOMAObject",
     "Collection",
+    "DataFrame",
+    "NDArray",
+    "CoordsData",
+    "DenseNDArray",
+    "SparseNDArray",
     "IOfN",
     "BatchSize",
 )

--- a/python-spec/src/somabase/base.py
+++ b/python-spec/src/somabase/base.py
@@ -1,15 +1,50 @@
-"""The most fundamental types used by the SOMA project."""
+"""Definitions of the most fundamental types used by the SOMA project.
 
-from typing import MutableMapping, TypeVar
+SOMA users should ordinarily not need to import this module directly; relevant
+members will be exported to the ``somabase`` namespace.
+"""
+
+import abc
+from typing import Any, MutableMapping, TypeVar
+
+from typing_extensions import Literal, LiteralString
 
 
-class SOMAObject:
+class SOMAObject(metaclass=abc.ABCMeta):
     """A sentinel interface indicating that this type is a SOMA object."""
 
     __slots__ = ()
 
-    # TODO: Consider if there are any more fundamental behaviors that should be
-    # pushed down to the SOMAObject level.
+    @property
+    def context(self) -> Any:
+        """A value storing implementation-specific configuration information.
+
+        This contains long-lived (i.e., not call-specific) information that is
+        used by the SOMA implementation to access storage. This may include
+        things like credentials, endpoint locations, or database connections.
+
+        End users should treat this as an opaque value. While it may be passed
+        from an existing SOMA object to be used in the creation of a new SOMA
+        object, it should not be inspected.
+        """
+        return None
+
+    @property
+    @abc.abstractmethod
+    def metadata(self) -> MutableMapping[str, Any]:
+        """The metadata of this SOMA object.
+
+        The returned value directly references the stored metadata; reads from
+        and writes to it (provided the object is opened) are reflected in
+        storage.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def soma_type(self) -> LiteralString:
+        """A string describing the SOMA type of this object."""
+        raise NotImplementedError()
 
 
 _ST = TypeVar("_ST", bound=SOMAObject)
@@ -25,3 +60,7 @@ class Collection(SOMAObject, MutableMapping[str, _ST]):
     """
 
     __slots__ = ()
+
+    @property
+    def soma_type(self) -> Literal["SOMACollection"]:
+        return "SOMACollection"

--- a/python-spec/src/somabase/data.py
+++ b/python-spec/src/somabase/data.py
@@ -1,0 +1,114 @@
+"""Definitions of data storage interfaces for SOMA implementations.
+
+SOMA users should ordinarily not need to import this module directly; relevant
+members will be exported to the ``somabase`` namespace.
+"""
+
+import abc
+from typing import Tuple
+
+import pyarrow
+from typing_extensions import Literal
+
+from somabase import base
+
+
+class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
+    """A multi-column table with a user-defined schema."""
+
+    __slots__ = ()
+
+    # TODO: Read/write.
+
+    # Metadata operations
+
+    @property
+    @abc.abstractmethod
+    def schema(self) -> pyarrow.Schema:
+        """The schema of the data in this dataframe."""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def index_column_names(self) -> Tuple[str, ...]:
+        """The names of the index (dimension) columns."""
+        raise NotImplementedError()
+
+    # Basic operations
+
+    @property
+    def soma_type(self) -> Literal["SOMADataFrame"]:
+        return "SOMADataFrame"
+
+
+class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
+    """Common behaviors of N-dimensional arrays of a single primitive type."""
+
+    __slots__ = ()
+
+    # TODO: Read/write.
+
+    # Metadata operations
+
+    @property
+    @abc.abstractmethod
+    def shape(self) -> Tuple[int, ...]:
+        """The length of each dimension of this array."""
+        raise NotImplementedError()
+
+    @property
+    def ndims(self) -> int:
+        """The Number of Dimensions in this array."""
+        return len(self.shape)
+
+    @property
+    @abc.abstractmethod
+    def schema(self) -> pyarrow.Schema:
+        """The schema of the data in this array."""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def is_sparse(self) -> bool:
+        """True if this array is sparse. False if this array is dense."""
+        raise NotImplementedError()
+
+
+class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
+    """A N-dimensional array stored densely."""
+
+    __slots__ = ()
+
+    # TODO: Read/write.
+
+    @property
+    def is_sparse(self) -> Literal[False]:
+        return False
+
+    @property
+    def soma_type(self) -> Literal["SOMADenseNDArray"]:
+        return "SOMADenseNDArray"
+
+
+class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
+    """A N-dimensional array stored sparsely."""
+
+    __slots__ = ()
+
+    # TODO: Read/write.
+
+    @property
+    def nnz(self) -> int:
+        """The number of values stored in the array, including explicit zeros.
+
+        For dense arrays, this will be the total size of the array.
+        """
+        raise NotImplementedError()
+
+    @property
+    def is_sparse(self) -> Literal[True]:
+        return True
+
+    @property
+    def soma_type(self) -> Literal["SOMASparseNDArray"]:
+        return "SOMASparseNDArray"

--- a/python-spec/src/somabase/options.py
+++ b/python-spec/src/somabase/options.py
@@ -18,8 +18,6 @@ class IOfN:
     approximately equal size.
     """
 
-    __slots__ = ()
-
     i: int = attrs.field()
     """Which partition to return (zero-indexed)."""
     n: int = attrs.field()
@@ -56,8 +54,6 @@ class BatchSize:
         BatchSize()
         # Will return automatically-sized batches.
     """
-
-    __slots__ = ()
 
     count: Optional[int] = attrs.field(default=None)
     """``arrow.Table``s with this number of rows will be returned."""

--- a/python-spec/src/somabase/options.py
+++ b/python-spec/src/somabase/options.py
@@ -4,13 +4,19 @@ These types are *concrete* and should be used as-is as inputs to the various
 SOMA types that require them, not reimplemented by the implementing package.
 """
 
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import attrs
 
 
+class ReadPartitions:
+    """Sentinel base class for read-partition types."""
+
+    __slots__ = ()
+
+
 @attrs.define(frozen=True)
-class IOfN:
+class IOfN(ReadPartitions):
     """Specifies that a read should return partition ``i`` out of ``n`` total.
 
     For a read operation that returns ``n`` partitions, the read operation will
@@ -69,3 +75,16 @@ class BatchSize:
             raise ValueError(f"If set, '{attr.name}' must be positive")
         if self.count and self.bytes:
             raise ValueError("Either 'count' or 'bytes' may be set, not both")
+
+
+PlatformConfig = Mapping[str, Any]
+"""Type alias for the ``platform_config`` parameter.
+
+``platform_config`` allows platform-specific configuration data to be passed
+to individual calls. Keys are the name of a SOMA implementation, each value is
+an implementation-defined configuration structure.
+"""
+
+
+ResultOrder = Any
+"""Type alias for result order. TODO: Define me (strings? enum?)."""


### PR DESCRIPTION
Split off from #56. This adds the data storage types (DataFrame, the NDArrays), but does not include the more complex read/write parts of the API. This will allow us to build things that refer to these types without waiting for the exact details of how reading and writing are implemented.