### PR TITLE
Shorten up constant declarations with `Final`.

### DIFF
--- a/python-spec/src/somabase/__init__.py
+++ b/python-spec/src/somabase/__init__.py
@@ -13,7 +13,6 @@ Collection = base.Collection
 
 DataFrame = data.DataFrame
 NDArray = data.NDArray
-CoordsData = data.CoordsData
 DenseNDArray = data.DenseNDArray
 SparseNDArray = data.SparseNDArray
 
@@ -25,7 +24,6 @@ __all__ = (
     "Collection",
     "DataFrame",
     "NDArray",
-    "CoordsData",
     "DenseNDArray",
     "SparseNDArray",
     "IOfN",

--- a/python-spec/src/somabase/base.py
+++ b/python-spec/src/somabase/base.py
@@ -7,13 +7,13 @@ members will be exported to the ``somabase`` namespace.
 import abc
 from typing import Any, MutableMapping, TypeVar
 
-from typing_extensions import Literal, LiteralString
+from typing_extensions import Final, LiteralString
 
 
 class SOMAObject(metaclass=abc.ABCMeta):
     """A sentinel interface indicating that this type is a SOMA object."""
 
-    __slots__ = ()
+    __slots__ = ("__weakref__",)
 
     @property
     def context(self) -> Any:
@@ -61,6 +61,4 @@ class Collection(SOMAObject, MutableMapping[str, _ST]):
 
     __slots__ = ()
 
-    @property
-    def soma_type(self) -> Literal["SOMACollection"]:
-        return "SOMACollection"
+    soma_type: Final = "SOMACollection"

--- a/python-spec/src/somabase/data.py
+++ b/python-spec/src/somabase/data.py
@@ -8,7 +8,7 @@ import abc
 from typing import Tuple
 
 import pyarrow
-from typing_extensions import Literal
+from typing_extensions import Final
 
 from somabase import base
 
@@ -36,9 +36,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
 
     # Basic operations
 
-    @property
-    def soma_type(self) -> Literal["SOMADataFrame"]:
-        return "SOMADataFrame"
+    soma_type: Final = "SOMADataFrame"
 
 
 class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
@@ -81,13 +79,8 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
 
     # TODO: Read/write.
 
-    @property
-    def is_sparse(self) -> Literal[False]:
-        return False
-
-    @property
-    def soma_type(self) -> Literal["SOMADenseNDArray"]:
-        return "SOMADenseNDArray"
+    is_sparse: Final = False
+    soma_type: Final = "SOMADenseNDArray"
 
 
 class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
@@ -105,10 +98,5 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
-    @property
-    def is_sparse(self) -> Literal[True]:
-        return True
-
-    @property
-    def soma_type(self) -> Literal["SOMASparseNDArray"]:
-        return "SOMASparseNDArray"
+    is_sparse: Final = True
+    soma_type: Final = "SOMASparseNDArray"


### PR DESCRIPTION
Abstract properties can be fulfilled by setting an attribute on the class itself, and using `Final` makes the type checker yell if you try to change it.

---

This used to be a much fancier idea that used descriptors to do more or less the same thing, but it would also ensure that nobody would change it at runtime. (That would have looked like this: https://github.com/single-cell-data/SOMA/commit/967ff84cdf30bb82b8caec84ad46097270e6dd13.) I don’t think the additional code there is worth it, though, since Final gives us (and users) static analysis security (and if users *do* start monkeying around with SOMA internals, if they break it they get to keep both pieces).