### PR TITLE
Add tools to create simple composed types and implement Measurement

### DIFF
--- a/python-spec/src/somabase/_wrap.py
+++ b/python-spec/src/somabase/_wrap.py
@@ -1,0 +1,220 @@
+from typing import (
+    Any,
+    Generic,
+    ItemsView,
+    Iterator,
+    KeysView,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    ValuesView,
+    overload,
+)
+
+import attrs
+from typing_extensions import Final
+
+from somabase import base
+
+_ST = TypeVar("_ST", bound=base.SOMAObject)
+_T = TypeVar("_T")
+
+_SENTINEL = object()
+
+
+class CollectionProxy(base.Collection[_ST]):
+    """Base class to forward SOMA collection methods to a "real" SOMA object.
+
+    This is intended for use as a mixin for SOMA objects that decorate standard
+    collection types with behaviors, e.g. the Experiment or Measurement classes.
+    It allows the separation of the behaviors (implemented in the decorator)
+    from the backend implementation (implemented in the wrapped object).
+    """
+
+    __slots__ = ("_backing",)
+
+    def __init__(self, backing: base.Collection[_ST]):
+        """Creates a new CollectionProxy backed by the given collection."""
+        self._backing: Final = backing
+        """The object that actually provides the indexing for this object."""
+
+    # SOMA methods
+
+    @property
+    def metadata(self) -> MutableMapping[str, str]:
+        return self._backing.metadata
+
+    def unwrap(self) -> base.Collection[_ST]:
+        """Unwrap gets the actual collection backed by this proxy."""
+        inst: base.Collection[_ST] = self
+        while isinstance(inst, CollectionProxy):
+            inst = inst._backing
+        return inst
+
+    # Sized
+
+    def __len__(self) -> int:
+        return len(self._backing)
+
+    # Iterable
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._backing)
+
+    # Container
+
+    def __contains__(self, key: Any) -> bool:
+        return key in self._backing
+
+    # Mapping
+
+    def __getitem__(self, key: str) -> _ST:
+        return self._backing[key]
+
+    @overload
+    def get(self, key: str) -> Optional[_ST]:
+        ...
+
+    @overload
+    def get(self, key: str, default: _T) -> Union[_ST, _T]:
+        ...
+
+    def get(
+        self, key: str, default: Union[_ST, _T, None] = None
+    ) -> Union[_ST, _T, None]:
+        return self._backing.get(key, default)
+
+    def keys(self) -> KeysView[str]:
+        return self._backing.keys()
+
+    def items(self) -> ItemsView[str, _ST]:
+        return self._backing.items()
+
+    def values(self) -> ValuesView[_ST]:
+        return self._backing.values()
+
+    # __reversed__ is not supported.
+
+    # MutableMapping
+
+    def __setitem__(self, key: str, value: _ST) -> None:
+        self._backing[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._backing[key]
+
+    def pop(
+        self,
+        key: str,
+        value: Union[_T, _ST] = _SENTINEL,  # type: ignore[assignment]
+    ) -> Union[_T, _ST]:
+        if value is _SENTINEL:
+            return self._backing.pop(key)
+        return self._backing.pop(key, value)
+
+    def popitem(self) -> Tuple[str, _ST]:
+        return self._backing.popitem()
+
+    def clear(self) -> None:
+        self._backing.clear()
+
+    def update(self, __other=(), **kwds) -> None:
+        return self._backing.update(__other, **kwds)
+
+    def setdefault(
+        self,
+        key: str,
+        default: _ST = None,  # type: ignore[assignment]
+    ) -> _ST:
+        return self._backing.setdefault(key, default)  # type: ignore[arg-type]
+
+
+@attrs.define()
+class item(Generic[_T]):
+    """Descriptor to transform property access into indexing.
+
+    This descriptor works with :class:`CollectionProxy` to allow for simple
+    specification of properties that reflect the members of the collection::
+
+        class WrapImpl(CollectionProxy):
+
+            first = item(str)
+            second = item(int, "2nd")
+
+        inst = WrapImpl(some_collection)
+
+        # This is equivalent to getting some_collection["first"]
+        inst.first
+
+        # This is equivalent to setting some_collection["2nd"]
+        inst.second = 500
+    """
+
+    typ: Optional[Type[_T]] = None
+    """The type we expect to return from this field."""
+
+    item_name: Optional[str] = None
+    """The name of the item we are getting (``x._backing["whatever"]``).
+
+    This uses the name of the field by default but can be manually overridden.
+    """
+
+    field_name: str = attrs.field(default="<unknown>", init=False)
+    """The name of this field (``x.whatever``). Set automatically."""
+
+    def __set_name__(self, owner: Type[CollectionProxy], name: str) -> None:
+        del owner  # unused
+        self.field_name = name
+        if self.item_name is None:
+            self.item_name = name
+
+    @overload
+    def __get__(self, inst: None, owner: Type[CollectionProxy]) -> "item[_T]":
+        ...
+
+    @overload
+    def __get__(self, inst: CollectionProxy, owner: Type[CollectionProxy]) -> _T:
+        ...
+
+    def __get__(
+        self, inst: Optional[CollectionProxy], owner: Type[CollectionProxy]
+    ) -> Union["item", _T]:
+        del owner  # unused
+        if not inst:
+            return self
+        assert self.item_name is not None
+        try:
+            # TODO: Type-check params/returns?
+            return inst[self.item_name]
+        except KeyError as ke:
+            raise AttributeError(
+                f"{_typename(inst)!r} object has no attribute {self.field_name!r}"
+            ) from ke
+
+    def __set__(self, inst: CollectionProxy, value: _T) -> None:
+        assert self.item_name is not None
+        # Pretend it's a MutableMapping for the type-checker.
+        # If it fails that's OK; we need to raise anyway.
+        try:
+            inst[self.item_name] = value
+        except KeyError as ke:
+            raise AttributeError(
+                f"{_typename(inst)!r} does not support assigning"
+                f" to item {self.item_name!r}"
+            ) from ke
+
+    def __delete__(self, inst: CollectionProxy) -> None:
+        assert self.item_name is not None
+        try:
+            del inst[self.item_name]
+        except KeyError as ke:
+            raise AttributeError(
+                f"{_typename(inst)} does not support deleting {self.item_name!r}"
+            ) from ke
+
+
+def _typename(x: object) -> str:
+    return type(x).__name__

--- a/python-spec/src/somabase/base.py
+++ b/python-spec/src/somabase/base.py
@@ -7,7 +7,7 @@ members will be exported to the ``somabase`` namespace.
 import abc
 from typing import Any, MutableMapping, TypeVar
 
-from typing_extensions import Final, LiteralString
+from typing_extensions import LiteralString
 
 
 class SOMAObject(metaclass=abc.ABCMeta):
@@ -61,4 +61,8 @@ class Collection(SOMAObject, MutableMapping[str, _ST]):
 
     __slots__ = ()
 
-    soma_type: Final = "SOMACollection"
+    # This is implemented as a property and not a literal so that it can be
+    # overridden with `Final` members in Collection specializations.
+    @property
+    def soma_type(self) -> LiteralString:
+        return "SOMACollection"

--- a/python-spec/src/somabase/composed.py
+++ b/python-spec/src/somabase/composed.py
@@ -1,0 +1,54 @@
+"""Implementations of the composed SOMA data types."""
+
+from typing_extensions import Final
+
+from somabase import _wrap
+from somabase import base
+from somabase import data
+
+
+class Measurement(_wrap.CollectionProxy):
+    """A set of annotated variables and values for a single measurement."""
+
+    __slots__ = ()
+
+    var = _wrap.item(data.DataFrame)
+    """Primary annotations on the variable axis for vars on this meansurement.
+
+    This annotates _columns_ of the ``X`` arrays. The contents of the
+    ``soma_joinid`` pseudo-column define the variable index domain (``varid``)
+    All variables for this measurement _must_ be defined in this dataframe.
+    """
+
+    X = _wrap.item(base.Collection[data.NDArray])
+    """A collection of matrices containing feature values.
+
+    Each matrix is indexed by ``[obsid, varid]``. Sparse and dense 2D arrays may
+    both be used in any combination in ``X``.
+    """
+
+    obsm = _wrap.item(base.Collection[data.DenseNDArray])
+    """Matrices containing annotations of each ``obs`` row.
+
+    This has the same shape as ``obs`` and is indexed with ``obsid``.
+    """
+
+    obsp = _wrap.item(base.Collection[data.SparseNDArray])
+    """Matrices containg pairwise annotations of each ``obs`` row.
+
+    This is indexed by ``[obsid_1, obsid_2]``.
+    """
+
+    varm = _wrap.item(base.Collection[data.DenseNDArray])
+    """Matrices containing annotations of each ``var`` row.
+
+    This has the same shape as ``var`` and is indexed with ``varid``.
+    """
+
+    varp = _wrap.item(base.Collection[data.SparseNDArray])
+    """Matrices containg pairwise annotations of each ``var`` row.
+
+    This is indexed by ``[varid_1, varid_2]``.
+    """
+
+    soma_type: Final = "SOMAMeasurement"

--- a/python-spec/testing/test_wrap.py
+++ b/python-spec/testing/test_wrap.py
@@ -1,0 +1,112 @@
+import unittest
+
+from somabase import _wrap
+from somabase import base
+
+
+class CollectionStub(base.Collection):
+    def __init__(self, data):
+        self._data = data
+
+    def __delitem__(self, item):
+        del self._data[item]
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __setitem__(self, item, value):
+        self._data[item] = value
+
+    @property
+    def metadata(self):
+        raise RuntimeError("[metadata stub]")
+
+
+class TestWrapper(unittest.TestCase):
+    def test_sanity(self):
+        data = {}
+        stub = CollectionStub(data)
+        wrapped = _wrap.CollectionProxy(stub)
+
+        wrapped["x"] = "y"
+        self.assertIn("x", wrapped)
+        self.assertEqual(wrapped["x"], "y")
+        self.assertEqual(data["x"], "y")
+        self.assertEqual("y", wrapped.get("x", "z"))
+        self.assertIsNone(wrapped.get("missing"))
+        self.assertEqual("?", wrapped.get("missing", "?"))
+
+        del wrapped["x"]
+        self.assertNotIn("x", wrapped)
+        self.assertNotIn("x", data)
+
+        wrapped.update(a="b", c="d", e="f")
+
+        self.assertEqual("ace", "".join(wrapped))
+        self.assertEqual({"a", "c", "e"}, set(wrapped.keys()))
+        self.assertEqual("bdf", "".join(wrapped.values()))
+        self.assertEqual(
+            [("a", "b"), ("c", "d"), ("e", "f")],
+            list(wrapped.items()),
+        )
+        self.assertEqual(("a", "b"), wrapped.popitem())
+        self.assertEqual(2, len(wrapped))
+        self.assertEqual("f", wrapped.setdefault("e", "z"))
+        self.assertEqual("y", wrapped.setdefault("x", "y"))
+        with self.assertRaises(KeyError):
+            wrapped.pop("missing")
+        self.assertEqual("f", wrapped.pop("e"))
+        self.assertEqual(2, len(wrapped))
+        self.assertEqual("q", wrapped.pop("missing", "q"))
+        wrapped.clear()
+        self.assertEqual(len(wrapped), 0)
+
+        with self.assertRaisesRegex(RuntimeError, r"\[metadata stub\]"):
+            wrapped.metadata
+
+        self.assertIs(stub, wrapped.unwrap())
+        double_wrap = _wrap.CollectionProxy(wrapped)
+        self.assertIs(stub, double_wrap.unwrap())
+
+
+class TestItem(unittest.TestCase):
+    def test_get(self):
+        the_a = _wrap.item(str)
+
+        class ItemHaver(_wrap.CollectionProxy):
+
+            a = the_a
+            b = _wrap.item(int, "base_b")
+
+        self.assertIs(the_a, ItemHaver.a)
+
+        data = {}
+        items = ItemHaver(data)
+        items["c"] = "d"
+
+        with self.assertRaises(AttributeError):
+            items.a
+        with self.assertRaises(AttributeError):
+            items.b
+        with self.assertRaises(AttributeError):
+            del items.a
+
+        self.assertEqual("d", items["c"])
+
+        data["a"] = "a"
+        data["base_b"] = 1
+        self.assertEqual("a", items.a)
+        self.assertEqual(1, items.b)
+
+        items.a = "hello"
+        items.b = 500
+
+        self.assertEqual(dict(a="hello", base_b=500, c="d"), data)
+        del items.a
+        self.assertEqual(dict(base_b=500, c="d"), data)


### PR DESCRIPTION
This change implements the Measurement "behavior class" in two steps:

 1. Creates a collection proxy that can be used as a base class to decorate Collections with additional behaviors.
      - Also a descriptor object that makes writing attribute-to-indexing bridges trivial.
 2. Implements Measurement using the proxy and the descriptors.

From here, implementing the other composed classes is quite straightforward. Once all are complete, TileDB-SOMA will no longer need to use its own custom implementation of Experiment and Measurement and can instead use the common wrapper classes around its own Collection objects.

---

This is the first part of the Grand Plan to separate behavior from storage. I’m sure there are parts of it that I have not explained quite as well as I had hoped so I am happy for questions or feedback on the direction as a whole in addition to the specifics of this code.