### PR TITLE
Add SOMADataFrame count accessor

### DIFF
--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -284,6 +284,7 @@ Parameters:
 | get soma_type                           | Returns the constant "SOMADataFrame"                                           |
 | get schema -> Arrow.Schema              | Return data schema, in the form of an Arrow Schema                             |
 | get index_column_names -> [string, ...] | Return index (dimension) column names.                                         |
+| get count -> int                        | Return the number of rows in the SOMADataFrame.                                |
 | read                                    | Read a subset of data from the SOMADataFrame                                   |
 | write                                   | Write a subset of data to the SOMADataFrame                                    |
 


### PR DESCRIPTION
One of the first questions users ask about a single-cell dataset is "how many cells and how many genes are in here?"

We need to let people answer this question.

This is essential for uptake UX.