### PR TITLE
Update licensing information for PyPI publishing.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021-2023 The Chan Zuckerberg Initiative Foundation
+Copyright (c) 2022-2023 TileDB, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -9,6 +9,8 @@ dynamic = ["version"]
 readme = "./README.md"
 dependencies = ["attrs>=22.1", "numpy>=1.21", "pyarrow", "typing-extensions"]
 requires-python = "~=3.7"
+urls = { repository = "https://github.com/single-cell-data/SOMA.git" }
+classifiers = ["License :: OSI Approved :: MIT License"]
 
 [project.optional-dependencies]
 dev = ["black", "isort", "setuptools-scm"]


### PR DESCRIPTION
Adds TileDB to the copyright file and sets MIT license metadata.