### PR TITLE
Set up project versioning for PyPI upload.

### DIFF
--- a/python-spec/.gitignore
+++ b/python-spec/.gitignore
@@ -1,2 +1,4 @@
 **/__pycache__
 **/*.egg-info
+dist
+src/somacore/_generated_version.py

--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -5,13 +5,16 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "somacore"
 description = "Python-language API specification and base utilities for implementation of the SOMA system."
-version = "0.0.0"
+dynamic = ["version"]
 readme = "./README.md"
-dependencies = ["attrs>=22.1", "pyarrow", "typing_extensions"]
+dependencies = ["attrs>=22.1", "pyarrow", "typing-extensions"]
 requires-python = "~=3.7"
 
 [project.optional-dependencies]
-dev = ["black", "isort"]
+dev = ["black", "isort", "setuptools-scm"]
+
+[tool.setuptools.dynamic]
+version = { attr = "somacore._version.version" }
 
 [tool.isort]
 profile = "black"

--- a/python-spec/setuptools-scm.toml
+++ b/python-spec/setuptools-scm.toml
@@ -1,0 +1,9 @@
+# setuptools-scm specific data from a pyproject.toml file.
+# Used by `write-version-file`.
+
+[tool.setuptools_scm]
+root = ".."
+write_to = "python-spec/src/somacore/_generated_version.py"
+# Keep Python executable package versioning separate from the spec and R impl
+# by requiring `python-` at the start of the tag (e.g. `python-v1.2.3`).
+tag_regex = '^python-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -4,9 +4,13 @@ Types will be defined in their own modules and then imported here for a single
 unified namespace.
 """
 
+from somacore import _version
 from somacore import base
 from somacore import data
 from somacore import options
+
+__version__ = _version.version
+__version_tuple__ = _version.version_tuple
 
 SOMAObject = base.SOMAObject
 Collection = base.Collection

--- a/python-spec/src/somacore/_version.py
+++ b/python-spec/src/somacore/_version.py
@@ -1,0 +1,36 @@
+"""Internal version information to indirect `_generated_version.py`.
+
+setuptools imports this module to find the version for the package at *build
+time*. We use this indirect module so that if the user has not run
+``write-version-file`` (e.g. they just did a fresh checkout), ``pip install``
+will still work. If we used ``setuptools.dynamic.version.attr`` and pointed it
+at `somacore._generated_version` directly, installing from a fresh checkout
+would fail.
+"""
+
+import pathlib
+from typing import Any, Dict, Tuple, Union
+
+
+def _read_version() -> Tuple[str, Tuple[Union[str, int], ...]]:
+    version_contents: Dict[str, Any] = dict(
+        version="0.0.0.dev+local-checkout",
+        version_tuple=(0, 0, 0, "dev", "local-checkout"),
+    )
+
+    # We do this the hard way since neither
+    #     from somacore import _generated_version
+    # nor
+    #     from . import _generated_version
+    # will work in the build environment.
+    gen_file = pathlib.Path(__file__).parent / "_generated_version.py"
+    try:
+        exec(gen_file.read_text(), version_contents)
+    except Exception:
+        # The generated file does not exist or is not valid.
+        # Ignore it.
+        pass
+    return version_contents["version"], version_contents["version_tuple"]
+
+
+version, version_tuple = _read_version()

--- a/python-spec/write-version-file
+++ b/python-spec/write-version-file
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Updates the `_version.py` file. Run this *before* building a package.
+# Make sure that you have `setuptools-scm` installed in your environment.
+#
+# When running `pip install`, pip gets the package directory and copies it out
+# to a temporary folder before executing anything related to setup (i.e., only
+# the contents of `python-spec/...`). This means that the `.git` folder, which
+# is in the parent directory, is absent, and thus setuptools-scm is not able to
+# detect the version at build time.
+#
+# To work around this, we just run this *before* doing any package related work
+# when running a build.
+
+set -ex
+cd "$(dirname "$0")"
+python -m setuptools_scm --config setuptools-scm.toml


### PR DESCRIPTION
Because our project is not at the root of our Git repository, we can't use straight `setuptools_scm`, so we do a little extra work.

- When building a package for release, run `write-version-file` before running `build`/`twine`.
- After that, everything works like normal.

---

A slightly different solution than we use in `TileDB-SOMA` but lets us have a purely declarative `pyproject.toml`, with just a bit of extra work in the build process.