### PR TITLE
Add `py.typed` marker file for downstream type checking.

### DIFF
--- a/python-spec/pyproject.toml
+++ b/python-spec/pyproject.toml
@@ -13,8 +13,11 @@ requires-python = "~=3.7"
 [project.optional-dependencies]
 dev = ["black", "isort", "setuptools-scm"]
 
-[tool.setuptools.dynamic]
-version = { attr = "somacore._version.version" }
+[tool.setuptools]
+packages.find.where = ["src"]
+package-data.somacore = ["py.typed"]
+dynamic.version.attr = "somacore._version.version"
+
 
 [tool.isort]
 profile = "black"

--- a/python-spec/src/somacore/py.typed
+++ b/python-spec/src/somacore/py.typed
@@ -1,0 +1,2 @@
+# Marker file to indicate that this package contains Python typing information,
+# and that mypy can use it to typecheck client code.


### PR DESCRIPTION
In order for mypy to use the types in an installed package's code for type-checking purposes, it needs this marker file.  See, for example, https://github.com/python/mypy/blob/master/mypy/py.typed