### PR TITLE
Add missing exported classes to somacore

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -15,6 +15,8 @@ __version_tuple__ = _version.version_tuple
 
 SOMAObject = base.SOMAObject
 Collection = base.Collection
+Experiment = base.Experiment
+Measurement = base.Measurement
 
 SimpleCollection = ephemeral.SimpleCollection
 
@@ -32,6 +34,8 @@ ResultOrder = options.ResultOrder
 __all__ = (
     "SOMAObject",
     "Collection",
+    "Experiment",
+    "Measurement",
     "DataFrame",
     "NDArray",
     "DenseNDArray",

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -66,3 +66,27 @@ class Collection(SOMAObject, MutableMapping[str, _ST]):
     @property
     def soma_type(self) -> LiteralString:
         return "SOMACollection"
+
+
+class Experiment(Collection[_ST]):
+    """
+    A specialized :class:`SOMACollection`, representing an annotated 2-D matrix of measurements.
+    """
+
+    # This is implemented as a property and not a literal so that it can be
+    # overridden with `Final` members in Experiment specializations.
+    @property
+    def soma_type(self) -> LiteralString:
+        return "SOMAExperiment"
+
+
+class Measurement(Collection[_ST]):
+    """
+    A set of measurements on a single set of variables (features) within a :class:`SOMAExperiment`.
+    """
+
+    # This is implemented as a property and not a literal so that it can be
+    # overridden with `Final` members in Measurement specializations.
+    @property
+    def soma_type(self) -> LiteralString:
+        return "SOMAMeasurement"


### PR DESCRIPTION
We need to export `Measurement` and `Experiment` in addition to `Collection`. While it is true the first two are specializations of the third, they are not all interchangeable. Specifically, we use `soma_type: Final = "SOMAMeasurement"` and `soma_type: Final = "SOMAExperiment"` as inherited in their analogous TileDB-SOMA classes. If `TileDB-SOMA`'s `Measurement` inherits from `somacore.Collection` then its `soma_type` will be wrong; which is of course unacceptable.

Context: https://github.com/single-cell-data/TileDB-SOMA/issues/669