### PR TITLE
Make all coordinates `coords` and add type annotations.

### DIFF
--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -7,7 +7,7 @@ Default values are provided here as a reference for implementors.
 """
 
 import abc
-from typing import Any, Iterator, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Iterator, Optional, Sequence, Tuple, TypeVar, Union
 
 import pyarrow
 from typing_extensions import Final
@@ -28,7 +28,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        ids,  # TODO: Specify type
+        coords: options.SparseDFCoords,
         column_names: Optional[Sequence[str]] = None,
         *,
         batch_size: options.BatchSize = options.BatchSize(),
@@ -161,7 +161,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        slices: Any,  # TODO: Define this type.
+        coords: options.SparseNDCoords,
         *,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -81,7 +81,7 @@ class ExperimentAxisQuery:
         """Returns ``obs`` as an Arrow table iterator. [lifecycle: experimental]"""
         obs_query = self._matrix_axis_query.obs
         return self._obs_df.read(
-            ids=obs_query.coords,
+            obs_query.coords,
             value_filter=obs_query.value_filter,
             column_names=column_names,
         )
@@ -92,7 +92,7 @@ class ExperimentAxisQuery:
         """Returns ``var`` as an Arrow table iterator. [lifecycle: experimental]"""
         var_query = self._matrix_axis_query.var
         return self._var_df.read(
-            ids=var_query.coords,
+            var_query.coords,
             value_filter=var_query.value_filter,
             column_names=column_names,
         )
@@ -295,7 +295,7 @@ class ExperimentAxisQuery:
 
         # Do the actual query.
         arrow_table = axis_df.read(
-            ids=axis_query.coords,
+            axis_query.coords,
             value_filter=axis_query.value_filter,
             column_names=query_columns,
         ).concat()
@@ -463,7 +463,7 @@ class _JoinIDCache:
 
 def _load_joinids(df: data.DataFrame, axq: axis.AxisQuery) -> pa.Array:
     tbl = df.read(
-        ids=axq.coords,
+        axq.coords,
         value_filter=axq.value_filter,
         column_names=["soma_joinid"],
     ).concat()


### PR DESCRIPTION
- Changes `ids`, `slices`, and `coords` to all be just `coords`
- Adds appropriate annotations for each type.

---

To see what this will look like when it propagates to `tiledbsoma`: https://github.com/single-cell-data/TileDB-SOMA/commit/ad1cbaeab348ba53e8b10df41098ade574e719ef