### PR TITLE
Re-enable `pip install --editable`; add mypy pre-commit step.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
@@ -8,10 +9,21 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
+  # This mypy step is not perfect; in the interest of not reproducing the entire
+  # dependency list here we only install `attrs`. It will catch a useful subset
+  # of errors but does not replace a full mypy run (either locally or in CI).
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+      - id: mypy
+        additional_dependencies: [attrs]
+
   - repo: https://github.com/psf/black
     rev: '22.12.0'
     hooks:
       - id: black
+
   - repo: https://github.com/PyCQA/isort
     rev: '5.11.4'
     hooks:

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -4,6 +4,8 @@ Types will be defined in their own modules and then imported here for a single
 unified namespace.
 """
 
+from typing import Tuple, Union
+
 from somacore import base
 from somacore import data
 from somacore import ephemeral
@@ -15,8 +17,8 @@ try:
     # This trips up mypy since it's a generated file:
     from somacore import _version  # type: ignore[attr-defined]
 
-    __version__ = _version.version
-    __version_tuple__ = _version.version_tuple
+    __version__: str = _version.version
+    __version_tuple__: Tuple[Union[int, str], ...] = _version.version_tuple
 except ImportError:
     __version__ = "0.0.0.dev+invalid"
     __version_tuple__ = (0, 0, 0, "dev", "invalid")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+# Minimal setup.py to enable editable install (pip install -e .).
+
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
- In the process of moving python installation config to the root on #80, I missed the `setup.py` file. This re-adds it to make ediable installs work again.
- Adds a mypy pre-commit step.