### PR TITLE
[python] Fast CSR loading for to_anndata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 build/
 dist/
 python-spec/src/somacore/_version.py
+**/venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "./python-spec/README.md"
 dependencies = [
   "anndata",
   "attrs>=22.1",
+  "numba",
   "numpy>=1.21",
   "pandas",
   "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ single_line_exclusions = ["typing", "typing_extensions"]
 
 [[tool.mypy.overrides]]
 # These dependencies do not currently have canonical type stubs.
-module = ["anndata", "pandas", "pyarrow", "scipy"]
+module = ["anndata", "numba", "pandas", "pyarrow", "scipy"]
 ignore_missing_imports = true

--- a/python-spec/requirements-py3.10.txt
+++ b/python-spec/requirements-py3.10.txt
@@ -2,7 +2,8 @@ anndata==0.8.0
 attrs==22.2.0
 h5py==3.7.0
 natsort==8.2.0
-numpy==1.24.1
+numba==0.56.4
+numpy==1.23.5
 packaging==23.0
 pandas==1.5.2
 pyarrow==10.0.1

--- a/python-spec/requirements-py3.7-lint.txt
+++ b/python-spec/requirements-py3.7-lint.txt
@@ -5,6 +5,7 @@ importlib-metadata==6.0.0
 mypy==0.991
 mypy-extensions==0.4.3
 natsort==8.2.0
+numba==0.56.4
 numpy==1.21.6
 packaging==23.0
 pandas==1.3.5

--- a/python-spec/requirements-py3.7.txt
+++ b/python-spec/requirements-py3.7.txt
@@ -3,6 +3,7 @@ attrs==22.2.0
 h5py==3.7.0
 importlib-metadata==6.0.0
 natsort==8.2.0
+numba==0.56.4
 numpy==1.21.6
 packaging==23.0
 pandas==1.3.5

--- a/python-spec/requirements-py3.8.txt
+++ b/python-spec/requirements-py3.8.txt
@@ -2,7 +2,8 @@ anndata==0.8.0
 attrs==22.2.0
 h5py==3.7.0
 natsort==8.2.0
-numpy==1.24.1
+numba==0.56.4
+numpy==1.23.5
 packaging==23.0
 pandas==1.5.2
 pyarrow==10.0.1

--- a/python-spec/requirements-py3.9.txt
+++ b/python-spec/requirements-py3.9.txt
@@ -2,7 +2,8 @@ anndata==0.8.0
 attrs==22.2.0
 h5py==3.7.0
 natsort==8.2.0
-numpy==1.24.1
+numba==0.56.4
+numpy==1.23.5
 packaging==23.0
 pandas==1.5.2
 pyarrow==10.0.1

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -88,7 +88,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @property
-    def ndims(self) -> int:
+    def ndim(self) -> int:
         """The Number of Dimensions in this array."""
         return len(self.shape)
 

--- a/python-spec/src/somacore/query/eager_iter.py
+++ b/python-spec/src/somacore/query/eager_iter.py
@@ -30,9 +30,10 @@ class _EagerIterator(Iterator[_T]):
             self._pool.shutdown()
 
     def __del__(self) -> None:
+        # Ensure the threadpool is cleaned up in the case where the
+        # iterator is not exhausted. For more information on __del__:
+        # https://docs.python.org/3/reference/datamodel.html#object.__del__
+
         super_del = getattr(super(), "__del__", lambda: None)
         super_del()
-
-        # admit the condition where the iterator was abandoned without
-        # completely exhausting the iterator
         self._cleanup()

--- a/python-spec/src/somacore/query/eager_iter.py
+++ b/python-spec/src/somacore/query/eager_iter.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional, TypeVar
 _T = TypeVar("_T")
 
 
-class EagerIterator(Iterator[_T]):
+class _EagerIterator(Iterator[_T]):
     def __init__(
         self,
         iterator: Iterator[_T],

--- a/python-spec/src/somacore/query/eager_iter.py
+++ b/python-spec/src/somacore/query/eager_iter.py
@@ -1,0 +1,38 @@
+from concurrent import futures
+from typing import Iterator, Optional, TypeVar
+
+_T = TypeVar("_T")
+
+
+class EagerIterator(Iterator[_T]):
+    def __init__(
+        self,
+        iterator: Iterator[_T],
+        pool: Optional[futures.Executor] = None,
+    ):
+        super().__init__()
+        self.iterator = iterator
+        self._pool = pool or futures.ThreadPoolExecutor()
+        self._own_pool = pool is None
+        self.future: futures.Future[_T] = self._pool.submit(next, self.iterator)  # type: ignore
+
+    def __next__(self) -> _T:
+        try:
+            res: _T = self.future.result()
+            self.future = self._pool.submit(next, self.iterator)  # type: ignore
+            return res
+        except StopIteration:
+            self._cleanup()
+            raise
+
+    def _cleanup(self) -> None:
+        if self._own_pool:
+            self._pool.shutdown()
+
+    def __del__(self) -> None:
+        super_del = getattr(super(), "__del__", lambda: None)
+        super_del()
+
+        # admit the condition where the iterator was abandoned without
+        # completely exhausting the iterator
+        self._cleanup()

--- a/python-spec/src/somacore/query/eager_iter.py
+++ b/python-spec/src/somacore/query/eager_iter.py
@@ -14,12 +14,12 @@ class _EagerIterator(Iterator[_T]):
         self.iterator = iterator
         self._pool = pool or futures.ThreadPoolExecutor()
         self._own_pool = pool is None
-        self.future: futures.Future[_T] = self._pool.submit(next, self.iterator)  # type: ignore
+        self._future: futures.Future[_T] = self._pool.submit(next, self.iterator)  # type: ignore
 
     def __next__(self) -> _T:
         try:
-            res: _T = self.future.result()
-            self.future = self._pool.submit(next, self.iterator)  # type: ignore
+            res: _T = self._future.result()
+            self._future = self._pool.submit(next, self.iterator)  # type: ignore
             return res
         except StopIteration:
             self._cleanup()

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -1,0 +1,290 @@
+import concurrent.futures as futures
+import os
+from typing import Any, List, Tuple, Type, cast
+
+import numba
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import pyarrow as pa
+from scipy import sparse
+
+from somacore.data import SparseNDArray
+from .eager_iter import EagerIterator
+
+
+@numba.jit(nopython=True, nogil=True)  # type: ignore
+def _accum_row_length(row_length, row_ind):
+    for i in range(len(row_ind)):
+        row_length[row_ind[i]] += 1
+    return None
+
+
+@numba.jit(nopython=True, nogil=True)  # type: ignore
+def _copy_chunk_range(
+    data_chunk,
+    row_ind_chunk,
+    col_ind_chunk,
+    data,
+    indices,
+    indptr,
+    row_rng_mask,
+    row_rng_val,
+):
+    for n in range(len(data_chunk)):
+        row = row_ind_chunk[n]
+        if (row & row_rng_mask) != row_rng_val:
+            continue
+        ptr = indptr[row]
+        indices[ptr] = col_ind_chunk[n]
+        data[ptr] = data_chunk[n]
+        indptr[row] += 1
+    return None
+
+
+@numba.jit(nopython=True, nogil=True)  # type: ignore
+def _copy_chunklist_range(
+    chunk_list: numba.typed.List,
+    data,
+    indices,
+    indptr,
+    row_rng_mask_bits,
+    job,
+):
+    row_rng_mask = (2**64 - 1) >> row_rng_mask_bits << row_rng_mask_bits
+    row_rng_val = job << row_rng_mask_bits
+    for data_chunk, row_ind_chunk, col_ind_chunk in chunk_list:
+        _copy_chunk_range(
+            data_chunk,
+            row_ind_chunk,
+            col_ind_chunk,
+            data,
+            indices,
+            indptr,
+            row_rng_mask,
+            row_rng_val,
+        )
+    return None
+
+
+@numba.jit(nopython=True, nogil=True)  # type: ignore
+def _finalize_indptr(indptr):
+    prev = 0
+    for r in range(len(indptr)):
+        t = indptr[r]
+        indptr[r] = prev
+        prev = t
+    return None
+
+
+def _select_dtype(
+    maxval: int,
+) -> Type[np.signedinteger[Any]]:
+    """
+    Ascertain the "best" dtype for a zero-based index. Given our
+    goal of minimizing memory use, "best" is currently defined as
+    smallest.
+    """
+    if maxval > np.iinfo(np.int32).max:
+        return np.int64
+    else:
+        return np.int32
+
+
+def _reindex_and_cast(
+    index: pd.Index, ids: npt.NDArray[np.int64], target_dtype: npt.DTypeLike
+) -> npt.NDArray[np.int64]:
+    return cast(
+        npt.NDArray[np.int64], index.get_indexer(ids).astype(target_dtype, copy=False)
+    )
+
+
+class CSRAccumulator:
+    """
+    Fast accumulator of a CSR, based upon COO input.
+    """
+
+    def __init__(
+        self,
+        obs_joinids: npt.NDArray[np.int64],
+        var_joinids: npt.NDArray[np.int64],
+        pool: futures.Executor,
+    ):
+        self.obs_joinids = obs_joinids
+        self.var_joinids = var_joinids
+        self.pool = pool
+
+        self.shape: Tuple[int, int] = (len(self.obs_joinids), len(self.var_joinids))
+        self.obs_indexer: pd.Index = pd.Index(self.obs_joinids)
+        self.var_indexer: pd.Index = pd.Index(self.var_joinids)
+        self.row_length: npt.NDArray[np.int64] = np.zeros(
+            (self.shape[0],), dtype=_select_dtype(self.shape[1])
+        )
+
+        # COO accumulated chunks, stored as list of triples (data, row_ind, col_ind)
+        self.coo_chunks: List[
+            Tuple[
+                npt.NDArray[np.number[Any]],
+                npt.NDArray[np.integer[Any]],
+                npt.NDArray[np.integer[Any]],
+            ]
+        ] = []
+
+    def append(
+        self, data: pa.Array, row_joinids: pa.Array, col_joinids: pa.Array
+    ) -> None:
+        """
+        At accumulation time, do several things:
+        * re-index to positional indices, and if possible, cast to smaller dtype
+          to minimize memory footprint (at cost of some amount of time)
+        * accumulate column counts by row, i.e., build the basis of the indptr
+        * cache the tuple of data, row, col
+        """
+        rows_future = self.pool.submit(
+            _reindex_and_cast,
+            self.obs_indexer,
+            row_joinids.to_numpy(),
+            _select_dtype(self.shape[0]),
+        )
+        cols_future = self.pool.submit(
+            _reindex_and_cast,
+            self.var_indexer,
+            col_joinids.to_numpy(),
+            _select_dtype(self.shape[1]),
+        )
+        row_ind = rows_future.result()
+        col_ind = cols_future.result()
+        self.coo_chunks.append((data.to_numpy(), row_ind, col_ind))
+        _accum_row_length(self.row_length, row_ind)
+
+    def finalize(
+        self,
+    ) -> Tuple[
+        npt.NDArray[np.number[Any]],  # data
+        npt.NDArray[np.integer[Any]],  # indptr
+        npt.NDArray[np.integer[Any]],  # indices
+        Tuple[int, int],  # shape
+    ]:
+        nnz = sum(len(chunk[0]) for chunk in self.coo_chunks)
+        index_dtype = _select_dtype(nnz)
+        if nnz == 0:
+            # no way to infer matrix dtype, so use default and return empty matrix
+            empty = sparse.csr_matrix((0, 0))
+            return empty.data, empty.indptr, empty.indices, (0, 0)
+
+        # cumsum row lengths to get indptr
+        indptr = np.empty((self.shape[0] + 1,), dtype=index_dtype)
+        indptr[0:1] = 0
+        np.cumsum(self.row_length, out=indptr[1:])
+
+        # Parallel copy of data and column indices
+        indices = np.empty((nnz,), dtype=index_dtype)
+        data = np.empty((nnz,), dtype=self.coo_chunks[0][0].dtype)
+
+        row_rng_mask_bits = 18
+        n_jobs = (self.shape[0] >> row_rng_mask_bits) + 1
+        chunk_list = numba.typed.List(self.coo_chunks)
+        futures.wait(
+            [
+                self.pool.submit(
+                    _copy_chunklist_range,
+                    chunk_list,
+                    data,
+                    indices,
+                    indptr,
+                    row_rng_mask_bits,
+                    job,
+                )
+                for job in range(0, n_jobs)
+            ]
+        )
+        _finalize_indptr(indptr)
+        return data, indptr, indices, self.shape
+
+
+def _read_csr(
+    matrix: SparseNDArray, obs_joinids: pa.Array, var_joinids: pa.Array
+) -> Tuple[
+    npt.NDArray[np.number[Any]],  # data
+    npt.NDArray[np.integer[Any]],  # indptr
+    npt.NDArray[np.integer[Any]],  # indices
+    Tuple[int, int],  # shape
+]:
+    if not isinstance(matrix, SparseNDArray) or matrix.ndim != 2:
+        raise TypeError("read_scipy_csr can only read from a 2D SparseNDArray")
+
+    max_workers = (os.cpu_count() or 4) + 2
+    with futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        acc = CSRAccumulator(
+            obs_joinids=obs_joinids, var_joinids=var_joinids, pool=pool
+        )
+        for tbl in EagerIterator(
+            matrix.read((obs_joinids, var_joinids)).tables(),
+            pool=pool,
+        ):
+            acc.append(tbl["soma_data"], tbl["soma_dim_0"], tbl["soma_dim_1"])
+
+        data, indptr, indices, shape = acc.finalize()
+
+    return data, indptr, indices, shape
+
+
+def read_scipy_csr(
+    matrix: SparseNDArray, obs_joinids: pa.Array, var_joinids: pa.Array
+) -> sparse.csr_matrix:
+    """
+    Given a 2D SparseNDArray and joinids for the two dimensions, read the
+    slice and return it as an SciPy sparse.csr_matrix.
+    """
+    data, indptr, indices, shape = _read_csr(matrix, obs_joinids, var_joinids)
+    csr = fast_create_scipy_csr_matrix(data, indices, indptr, shape=shape)
+    return csr
+
+
+def read_arrow_csr(
+    matrix: SparseNDArray, obs_joinids: pa.Array, var_joinids: pa.Array
+) -> pa.SparseCSRMatrix:
+    """
+    Given a 2D SparseNDArray and joinids for the two dimensions, read the
+    slice and return it as an SciPy sparse.csr_matrix.
+    """
+    data, indptr, indices, shape = _read_csr(matrix, obs_joinids, var_joinids)
+    csr = pa.SparseCSRMatrix.from_numpy(data, indptr, indices, shape=shape)
+    return csr
+
+
+def fast_create_scipy_csr_matrix(
+    data: npt.NDArray[np.number[Any]],
+    indices: npt.NDArray[np.integer[Any]],
+    indptr: npt.NDArray[np.integer[Any]],
+    shape: Tuple[int, int],
+) -> sparse.csr_matrix:
+    """
+    Create a Scipy sparse.csr_matrix from
+
+    This ugliness is to bypass the O(N) scan that scipy.sparse._cs_matrix.__init__
+    does when a new compressed matrix is created. Given valid inputs, this code is
+    equivalent to:
+        sparse.csr_matrix((data, indices, indptr), shape=shape)
+    without the overhead of the scan.
+
+    See https://github.com/scipy/scipy/issues/11496 for details on the bug.
+    """
+    matrix = sparse.csr_matrix.__new__(sparse.csr_matrix)
+    matrix.data = data
+    matrix.indices = indices
+    matrix.indptr = indptr
+    matrix._shape = shape
+    return matrix
+
+
+def fast_SparseCSRMatrix_to_scipy(csr: pa.SparseCSRMatrix) -> sparse.csr_matrix:
+    """
+    Convert Arrow SparseCSRMatrix to scipy.sparse.csr_matrix. Semantically the same
+    as ``csr.to_scipy()``, but without the performance penalty/bug noted in
+    https://github.com/scipy/scipy/issues/11496
+    """
+    data, indptr, indices = csr.to_numpy()
+    data, indptr, indices = data.ravel(), indptr.ravel(), indices.ravel()
+    matrix = fast_create_scipy_csr_matrix(data, indices, indptr, csr.shape)
+    return matrix

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -1,6 +1,6 @@
 import concurrent.futures as futures
 import os
-from typing import Any, List, Tuple, Type, cast
+from typing import List, Tuple, Type, cast
 
 import numba
 import numpy as np
@@ -80,7 +80,7 @@ def _finalize_indptr(indptr):
 
 def _select_dtype(
     maxval: int,
-) -> Type[np.signedinteger[Any]]:
+) -> Type[np.signedinteger]:
     """
     Ascertain the "best" dtype for a zero-based index. Given our
     goal of minimizing memory use, "best" is currently defined as
@@ -125,9 +125,9 @@ class CSRAccumulator:
         # COO accumulated chunks, stored as list of triples (data, row_ind, col_ind)
         self.coo_chunks: List[
             Tuple[
-                npt.NDArray[np.number[Any]],
-                npt.NDArray[np.integer[Any]],
-                npt.NDArray[np.integer[Any]],
+                npt.NDArray[np.number],
+                npt.NDArray[np.integer],
+                npt.NDArray[np.integer],
             ]
         ] = []
 
@@ -161,9 +161,9 @@ class CSRAccumulator:
     def finalize(
         self,
     ) -> Tuple[
-        npt.NDArray[np.number[Any]],  # data
-        npt.NDArray[np.integer[Any]],  # indptr
-        npt.NDArray[np.integer[Any]],  # indices
+        npt.NDArray[np.number],  # data
+        npt.NDArray[np.integer],  # indptr
+        npt.NDArray[np.integer],  # indices
         Tuple[int, int],  # shape
     ]:
         nnz = sum(len(chunk[0]) for chunk in self.coo_chunks)
@@ -206,9 +206,9 @@ class CSRAccumulator:
 def _read_csr(
     matrix: SparseNDArray, obs_joinids: pa.Array, var_joinids: pa.Array
 ) -> Tuple[
-    npt.NDArray[np.number[Any]],  # data
-    npt.NDArray[np.integer[Any]],  # indptr
-    npt.NDArray[np.integer[Any]],  # indices
+    npt.NDArray[np.number],  # data
+    npt.NDArray[np.integer],  # indptr
+    npt.NDArray[np.integer],  # indices
     Tuple[int, int],  # shape
 ]:
     if not isinstance(matrix, SparseNDArray) or matrix.ndim != 2:
@@ -255,9 +255,9 @@ def read_arrow_csr(
 
 
 def fast_create_scipy_csr_matrix(
-    data: npt.NDArray[np.number[Any]],
-    indices: npt.NDArray[np.integer[Any]],
-    indptr: npt.NDArray[np.integer[Any]],
+    data: npt.NDArray[np.number],
+    indices: npt.NDArray[np.integer],
+    indptr: npt.NDArray[np.integer],
     shape: Tuple[int, int],
 ) -> sparse.csr_matrix:
     """

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -134,7 +134,7 @@ class _CSRAccumulator:
         indices = np.empty((nnz,), dtype=index_dtype)
         data = np.empty((nnz,), dtype=self.coo_chunks[0][2].dtype)
 
-        # empirically determined value. Needs to be large enough for reasonable
+        # Empirically determined value. Needs to be large enough for reasonable
         # concurrency, without excessive write cache conflict. Controls the
         # number of rows that are processed in a single thread, and therefore
         # is the primary tuning parameter related to concurrency.

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -9,9 +9,8 @@ import pandas as pd
 import pyarrow as pa
 from scipy import sparse
 
-from somacore import data as scd
-
-from .eager_iter import _EagerIterator
+import somacore.data as scd
+from somacore.query import eager_iter
 
 
 class CSRAccumulatorFinalResult(NamedTuple):
@@ -229,7 +228,7 @@ def _read_csr(
         acc = CSRAccumulator(
             obs_joinids=obs_joinids, var_joinids=var_joinids, pool=pool
         )
-        for tbl in _EagerIterator(
+        for tbl in eager_iter._EagerIterator(
             matrix.read((obs_joinids, var_joinids)).tables(),
             pool=pool,
         ):

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 from scipy import sparse
 
 from somacore.data import SparseNDArray
+
 from .eager_iter import EagerIterator
 
 

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -15,6 +15,8 @@ from somacore import composed
 from somacore import data
 from somacore.query import axis
 
+from .fast_csr import read_scipy_csr
+
 
 class AxisColumnNames(TypedDict, total=False):
     """Specifies column names for experiment axis query read operations."""
@@ -156,14 +158,20 @@ class ExperimentAxisQuery:
         :param X_layers: Additional X layers to read and return
             in the ``layers`` slot.
         """
-        query_result = self._read(
+        # query_result = self._read(
+        #     X_name,
+        #     column_names=column_names or AxisColumnNames(obs=None, var=None),
+        #     X_layers=X_layers,
+        # )
+
+        # # AnnData uses positional indexing
+        # return self._indexer.rewrite(query_result).to_anndata()
+
+        return self._read(
             X_name,
             column_names=column_names or AxisColumnNames(obs=None, var=None),
             X_layers=X_layers,
-        )
-
-        # AnnData uses positional indexing
-        return self._indexer.rewrite(query_result).to_anndata()
+        ).to_anndata()
 
     # Context management
 
@@ -233,17 +241,15 @@ class ExperimentAxisQuery:
 
         obs_table, var_table = self._read_both_axes(column_names)
 
-        x_tables = {
-            # TODO: could also be done concurrently
-            _xname: all_x_arrays[_xname]
-            .read((self.obs_joinids(), self.var_joinids()))
-            .tables()
-            .concat()
+        x_matrices = {
+            _xname: read_scipy_csr(
+                all_x_arrays[_xname], self.obs_joinids(), self.var_joinids()
+            )
             for _xname in all_x_arrays
         }
 
-        x = x_tables.pop(X_name)
-        return _AxisQueryResult(obs=obs_table, var=var_table, X=x, X_layers=x_tables)
+        x = x_matrices.pop(X_name)
+        return _AxisQueryResult(obs=obs_table, var=var_table, X=x, X_layers=x_matrices)
 
     def _read_both_axes(
         self,
@@ -369,10 +375,10 @@ class _AxisQueryResult:
     """Experiment.obs query slice, as an Arrow Table"""
     var: pa.Table
     """Experiment.ms[...].var query slice, as an Arrow Table"""
-    X: pa.Table
-    """Experiment.ms[...].X[...] query slice, as an Arrow Table"""
-    X_layers: Dict[str, pa.Table] = attrs.field(factory=dict)
-    """Any additional X layers requested, as Arrow Table(s)"""
+    X: sparse.csr_matrix
+    """Experiment.ms[...].X[...] query slice, as an SciPy sparse.csr_matrix """
+    X_layers: Dict[str, sparse.csr_matrix] = attrs.field(factory=dict)
+    """Any additional X layers requested, as SciPy sparse.csr_matrix(s)"""
 
     def to_anndata(self) -> anndata.AnnData:
         """Convert to AnnData"""
@@ -382,17 +388,9 @@ class _AxisQueryResult:
         var = self.var.to_pandas()
         var.index = var.index.map(str)
 
-        shape = (len(obs), len(var))
-
-        x = self.X
-        if x is not None:
-            x = _arrow_to_scipy_csr(x, shape)
-
-        layers = {
-            name: _arrow_to_scipy_csr(table, shape)
-            for name, table in self.X_layers.items()
-        }
-        return anndata.AnnData(X=x, obs=obs, var=var, layers=(layers or None))
+        return anndata.AnnData(
+            X=self.X, obs=obs, var=var, layers=(self.X_layers or None)
+        )
 
 
 class _Axis(enum.Enum):
@@ -500,71 +498,8 @@ class _AxisIndexer:
     def by_var(self, coords: _Numpyable) -> npt.NDArray[np.intp]:
         return self._var_index.get_indexer(_to_numpy(coords))
 
-    def rewrite(self, qr: _AxisQueryResult) -> _AxisQueryResult:
-        """Rewrite the result to prepare for AnnData positional indexing."""
-        return attrs.evolve(
-            qr,
-            X=self._rewrite_matrix(qr.X),
-            X_layers={
-                name: self._rewrite_matrix(matrix)
-                for name, matrix in qr.X_layers.items()
-            },
-        )
-
-    def _rewrite_matrix(self, x_table: pa.Table) -> pa.Table:
-        """
-        Private convenience function to convert axis dataframe to X matrix joins
-        from ``soma_joinid``-based joins to positionally indexed joins
-        (like AnnData uses).
-
-        Input is organized as:
-            obs[i] annotates X[ obs[i].soma_joinid, : ]
-        and
-            var[j] annotates X[ :, var[j].soma_joinid ]
-
-        Output is organized as:
-            obs[i] annotates X[i, :]
-        and
-            var[j] annotates X[:, j]
-
-        In addition, the ``soma_joinid`` column is dropped from axis dataframes.
-        """
-
-        return pa.Table.from_arrays(
-            (
-                self.by_obs(x_table["soma_dim_0"]),
-                self.by_var(x_table["soma_dim_1"]),
-                # This consolidates chunks as a side effect.
-                x_table["soma_data"].to_numpy(),
-            ),
-            names=("_dim_0", "_dim_1", "soma_data"),
-        )
-
 
 def _to_numpy(it: _Numpyable) -> np.ndarray:
     if isinstance(it, np.ndarray):
         return it
     return it.to_numpy()
-
-
-def _arrow_to_scipy_csr(
-    arrow_table: pa.Table, shape: Tuple[int, int]
-) -> sparse.csr_matrix:
-    """
-    Private utility which converts a table repesentation of X to a CSR matrix.
-
-    IMPORTANT: by convention, assumes that the data is positionally indexed (hence
-    the use of _dim_{n} rather than soma_dim{n}).
-
-    See query.py::_rewrite_X_for_positional_indexing for more info.
-    """
-    assert "_dim_0" in arrow_table.column_names, "X must be positionally indexed"
-    assert "_dim_1" in arrow_table.column_names, "X must be positionally indexed"
-
-    return sparse.csr_matrix(
-        (
-            arrow_table["soma_data"].to_numpy(),
-            (arrow_table["_dim_0"].to_numpy(), arrow_table["_dim_1"].to_numpy()),
-        ),
-        shape=shape,
-    )

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -158,15 +158,6 @@ class ExperimentAxisQuery:
         :param X_layers: Additional X layers to read and return
             in the ``layers`` slot.
         """
-        # query_result = self._read(
-        #     X_name,
-        #     column_names=column_names or AxisColumnNames(obs=None, var=None),
-        #     X_layers=X_layers,
-        # )
-
-        # # AnnData uses positional indexing
-        # return self._indexer.rewrite(query_result).to_anndata()
-
         return self._read(
             X_name,
             column_names=column_names or AxisColumnNames(obs=None, var=None),


### PR DESCRIPTION
This PR addresses the peformance issues noted in single-cell-data/TileDB-SOMA#719.  In particular, loading large AnnData requires CSR sparse matrices, which are very slow to convert from COO to CSR.  This PR adds a fast-path converter for Python, implementing two changes:
* parallelized COO to CSR conversion
* eager reading of the COO data from SOMA, allowing some concurrent COO-to-CSR work to overlap with the data reading.

In addition, this change uses substantially less memory for the conversion, allowing larger datasets to be loaded into CSR, and therefore into AnnData.

Before/after benchmarks show 1.5-4X speed-ups when the work fits in RAM (tested on r6i instance types with data on S3).  In cases where paging occured, speed-ups were dramatically larger (e.g., 20X).

See also, related PR single-cell-data/TileDB-SOMA#745
