### PR TITLE
Create `add` method for base Collection type

### DIFF
--- a/python-spec/src/somacore/_wrap.py
+++ b/python-spec/src/somacore/_wrap.py
@@ -18,6 +18,7 @@ import attrs
 from typing_extensions import Final
 
 from somacore import base
+from somacore import options
 
 _ST = TypeVar("_ST", bound=base.SOMAObject)
 _T = TypeVar("_T")
@@ -53,6 +54,21 @@ class CollectionProxy(base.Collection[_ST]):
         while isinstance(inst, CollectionProxy):
             inst = inst._backing
         return inst
+
+    def add(
+        self,
+        key: str,
+        cls: Type[_ST],
+        *,
+        uri: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> _ST:
+        return self._backing.add(key, cls, uri=uri, platform_config=platform_config)
+
+    def set(
+        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
+    ) -> None:
+        self._backing.set(key, value, use_relative_uri=use_relative_uri)
 
     # Sized
 

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -5,9 +5,11 @@ members will be exported to the ``somacore`` namespace.
 """
 
 import abc
-from typing import Any, MutableMapping, TypeVar
+from typing import Any, MutableMapping, Optional, Type, TypeVar
 
 from typing_extensions import LiteralString
+
+from somacore import options
 
 
 class SOMAObject(metaclass=abc.ABCMeta):
@@ -51,7 +53,7 @@ _ST = TypeVar("_ST", bound=SOMAObject)
 """Generic type variable for any SOMA object."""
 
 
-class Collection(SOMAObject, MutableMapping[str, _ST]):
+class Collection(SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
     """A generic string-keyed collection of :class:`SOMAObject`s.
 
     The generic type specifies what type the Collection may contain. At its
@@ -60,6 +62,71 @@ class Collection(SOMAObject, MutableMapping[str, _ST]):
     """
 
     __slots__ = ()
+
+    @abc.abstractmethod
+    def add(
+        self,
+        key: str,
+        cls: Type[_ST],
+        *,
+        uri: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> _ST:
+        """Creates a child member of this collection and adds it.
+
+        This allows the creation of child objects of any type::
+
+            # Create a child Measurement object at the key "density"
+            # with default settings.
+            #
+            # This creates both the backing Measurement collection, as well as
+            # the necessary sub-elements to have a complete Measurement.
+            density = the_collection.create("density", somacore.Measurement)
+
+            # Create a child DataFrame at the key "data" with a custom URI
+            # and additional platform configuration.
+            data = the_collection.create(
+                "data",
+                somacore.DataFrame,
+                uri="file:///custom/path/to/df",
+                platform_config={"somaimpl": ...},
+            )
+
+        By default (in situations where it is possible to do so), the default
+        URI used should be a relative URI with its final component as the key.
+        For instance, adding sub-element ``data`` to a Collection located at
+        ``file:///path/to/coll`` should by default use
+        ``file:///path/to/coll/data`` as its URI if possible. If this is not
+        possible
+
+        :param key: The key that this child should live at (i.e., it will be
+            accessed via ``the_collection[key]``).
+        :param cls: The type of child that should be added.
+        :param uri: If provided, overrides the default URI that would be used
+            to create this object. This may be absolute or relative.
+        :param platform_config: Platform-specific configuration options used
+            when creating the child.
+        """
+        raise NotImplementedError()
+
+    def __setitem__(self, key: str, value: _ST) -> None:
+        self.set(key, value)
+
+    @abc.abstractmethod
+    def set(
+        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
+    ) -> None:
+        """Sets an entry of this collection.
+
+        :param use_relative_uri: Determines whether to store the collection
+            entry with a relative URI (provided the storage engine supports it).
+            If ``None`` (the default), will automatically determine whether to
+            use an absolute or relative URI based on their relative location
+            (if supported by the storage engine).
+            If ``True``, will always use a relative URI.
+            If ``False``, will always use an absolute URI.
+        """
+        raise NotImplementedError()
 
     # This is implemented as a property and not a literal so that it can be
     # overridden with `Final` members in Collection specializations.

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -110,6 +110,19 @@ class Collection(SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def __setitem__(self, key: str, value: _ST) -> None:
+        """Sets an entry into this collection.
+
+        Important note: Because parent objects may need to share
+        implementation-internal state with children, when you set an item in a
+        collection, it is not guaranteed that the SOMAObject instance available
+        by accessing the collection is the same as the one that was set::
+
+            some_collection["thing"] = my_soma_object
+            added_soma_object = some_collection["thing"]
+            my_soma_object is added_soma_object  # could be False
+
+        The two objects *will* refer to the same stored data.
+        """
         self.set(key, value)
 
     @abc.abstractmethod

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -97,7 +97,7 @@ class Collection(SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
         For instance, adding sub-element ``data`` to a Collection located at
         ``file:///path/to/coll`` should by default use
         ``file:///path/to/coll/data`` as its URI if possible. If this is not
-        possible
+        possible, the collection may construct a new non-relative URI.
 
         :param key: The key that this child should live at (i.e., it will be
             accessed via ``the_collection[key]``).
@@ -110,7 +110,14 @@ class Collection(SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def __setitem__(self, key: str, value: _ST) -> None:
-        """Sets an entry into this collection.
+        """Sets an entry into this collection. See :meth:`set` for details."""
+        self.set(key, value)
+
+    @abc.abstractmethod
+    def set(
+        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
+    ) -> None:
+        """Sets an entry of this collection.
 
         Important note: Because parent objects may need to share
         implementation-internal state with children, when you set an item in a
@@ -122,21 +129,15 @@ class Collection(SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
             my_soma_object is added_soma_object  # could be False
 
         The two objects *will* refer to the same stored data.
-        """
-        self.set(key, value)
-
-    @abc.abstractmethod
-    def set(
-        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
-    ) -> None:
-        """Sets an entry of this collection.
 
         :param use_relative_uri: Determines whether to store the collection
             entry with a relative URI (provided the storage engine supports it).
             If ``None`` (the default), will automatically determine whether to
             use an absolute or relative URI based on their relative location
             (if supported by the storage engine).
-            If ``True``, will always use a relative URI.
+            If ``True``, will always use a relative URI. If the new child does
+            not share a relative URI base, or use of relative URIs is not
+            possible at all, the collection should throw an exception.
             If ``False``, will always use an absolute URI.
         """
         raise NotImplementedError()


### PR DESCRIPTION
Also pulls the `set` method for Collections from TileDB-SOMA, allowing a user to decide whether a collection entry should be stored with an absolute or relative URI.

This is the first step in reworking the SOMA object creation and opening protocols with the eventual goal that (unless the user does something weird) user code should only ever have to deal with fully-set-up SOMA objects and collections.

---

My biggest question here is: Does it make sense to import the `set` method from tiledbsoma?