### PR TITLE
Add ruff (a fast Python linter) to pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     rev: '5.11.4'
     hooks:
       - id: isort
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.226
+    hooks:
+    - id: ruff

--- a/python-spec/src/somacore/query/eager_iter.py
+++ b/python-spec/src/somacore/query/eager_iter.py
@@ -14,12 +14,12 @@ class _EagerIterator(Iterator[_T]):
         self.iterator = iterator
         self._pool = pool or futures.ThreadPoolExecutor()
         self._own_pool = pool is None
-        self._future: futures.Future[_T] = self._pool.submit(next, self.iterator)  # type: ignore
+        self._future = self._pool.submit(self.iterator.__next__)
 
     def __next__(self) -> _T:
         try:
-            res: _T = self._future.result()
-            self._future = self._pool.submit(next, self.iterator)  # type: ignore
+            res = self._future.result()
+            self._future = self._pool.submit(self.iterator.__next__)
             return res
         except StopIteration:
             self._cleanup()

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -100,11 +100,15 @@ class ExperimentAxisQuery:
         )
 
     def obs_joinids(self) -> pa.Array:
-        """Returns ``obs`` ``soma_joinids`` as an Arrow array. [lifecycle: experimental]"""
+        """Returns ``obs`` ``soma_joinids`` as an Arrow array.
+        [lifecycle: experimental]
+        """
         return self._joinids.obs
 
     def var_joinids(self) -> pa.Array:
-        """Returns ``var`` ``soma_joinids`` as an Arrow array. [lifecycle: experimental]"""
+        """Returns ``var`` ``soma_joinids`` as an Arrow array.
+        [lifecycle: experimental]
+        """
         return self._joinids.var
 
     @property


### PR DESCRIPTION
Shamelessly stolen from the TileDB SOMA repository [1], this change adds ruff to the pre-commit workflow.

Also does some minor changes to placate ruff so we start off with a completely clean slate.

[1] https://github.com/single-cell-data/TileDB-SOMA/pull/751

(cc @gsakkis)