### PR TITLE
[python] Make imports relative and shuffle privacy underscores around.

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -11,6 +11,7 @@ from . import data
 from . import ephemeral
 from . import options
 from . import query
+from .query import axis
 
 try:
     # This trips up mypy since it's a generated file:
@@ -38,7 +39,7 @@ IOfN = options.IOfN
 BatchSize = options.BatchSize
 ResultOrder = options.ResultOrder
 
-AxisQuery = query.AxisQuery
+AxisQuery = axis.AxisQuery
 ExperimentAxisQuery = query.ExperimentAxisQuery
 
 __all__ = (

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -6,16 +6,15 @@ unified namespace.
 
 from typing import Tuple, Union
 
-from somacore import base
-from somacore import data
-from somacore import ephemeral
-from somacore import options
-from somacore.query import axis
-from somacore.query import query
+from . import base
+from . import data
+from . import ephemeral
+from . import options
+from . import query
 
 try:
     # This trips up mypy since it's a generated file:
-    from somacore import _version  # type: ignore[attr-defined]
+    from . import _version  # type: ignore[attr-defined]
 
     __version__: str = _version.version
     __version_tuple__: Tuple[Union[int, str], ...] = _version.version_tuple
@@ -39,7 +38,7 @@ IOfN = options.IOfN
 BatchSize = options.BatchSize
 ResultOrder = options.ResultOrder
 
-AxisQuery = axis.AxisQuery
+AxisQuery = query.AxisQuery
 ExperimentAxisQuery = query.ExperimentAxisQuery
 
 __all__ = (

--- a/python-spec/src/somacore/_wrap.py
+++ b/python-spec/src/somacore/_wrap.py
@@ -17,8 +17,8 @@ from typing import (
 import attrs
 from typing_extensions import Final
 
-from somacore import base
-from somacore import options
+from . import base
+from . import options
 
 _ST = TypeVar("_ST", bound=base.SOMAObject)
 _T = TypeVar("_T")

--- a/python-spec/src/somacore/composed.py
+++ b/python-spec/src/somacore/composed.py
@@ -2,11 +2,11 @@
 
 from typing_extensions import Final
 
-from somacore import _wrap
-from somacore import base
-from somacore import data
-from somacore.query import axis
-from somacore.query import query
+from . import _wrap
+from . import base
+from . import data
+from . import query
+from .query import axis
 
 
 class Measurement(_wrap.CollectionProxy):

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -12,8 +12,8 @@ from typing import Iterator, Optional, Sequence, Tuple, TypeVar, Union
 import pyarrow
 from typing_extensions import Final
 
-from somacore import base
-from somacore import options
+from . import base
+from . import options
 
 _RO_AUTO = options.ResultOrder.AUTO
 

--- a/python-spec/src/somacore/ephemeral.py
+++ b/python-spec/src/somacore/ephemeral.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Iterator, Optional, Type, TypeVar
 
 from typing_extensions import final
 
-from somacore import base
-from somacore import options
+from . import base
+from . import options
 
 _ST = TypeVar("_ST", bound=base.Collection)
 

--- a/python-spec/src/somacore/query/__init__.py
+++ b/python-spec/src/somacore/query/__init__.py
@@ -1,0 +1,7 @@
+from . import axis
+from . import query
+
+ExperimentAxisQuery = query.ExperimentAxisQuery
+AxisQuery = axis.AxisQuery
+
+__all__ = ("ExperimentAxisQuery",)

--- a/python-spec/src/somacore/query/_eager_iter.py
+++ b/python-spec/src/somacore/query/_eager_iter.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional, TypeVar
 _T = TypeVar("_T")
 
 
-class _EagerIterator(Iterator[_T]):
+class EagerIterator(Iterator[_T]):
     def __init__(
         self,
         iterator: Iterator[_T],

--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 from scipy import sparse
 
 from .. import data as scd
-from . import eager_iter
+from . import _eager_iter
 
 
 def read_scipy_csr(
@@ -264,7 +264,7 @@ def _read_csr(
         acc = _CSRAccumulator(
             obs_joinids=obs_joinids, var_joinids=var_joinids, pool=pool
         )
-        for tbl in eager_iter._EagerIterator(
+        for tbl in _eager_iter.EagerIterator(
             matrix.read((obs_joinids, var_joinids)).tables(),
             pool=pool,
         ):

--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -5,7 +5,7 @@ import numpy as np
 import pyarrow as pa
 from typing_extensions import TypeGuard
 
-from somacore import options
+from .. import options
 
 
 def _canonicalize_coords(

--- a/python-spec/src/somacore/query/fast_csr.py
+++ b/python-spec/src/somacore/query/fast_csr.py
@@ -3,14 +3,15 @@ from concurrent import futures
 from typing import List, NamedTuple, Tuple, Type, cast
 
 import numba
+import numba.typed
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
 from scipy import sparse
 
-import somacore.data as scd
-from somacore.query import eager_iter
+from .. import data as scd
+from . import eager_iter
 
 
 def read_scipy_csr(

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -13,8 +13,8 @@ from typing_extensions import Literal, TypedDict, assert_never
 
 from .. import composed
 from .. import data
+from . import _fast_csr
 from . import axis
-from . import fast_csr
 
 
 class AxisColumnNames(TypedDict, total=False):
@@ -73,7 +73,7 @@ class ExperimentAxisQuery:
 
         self._matrix_axis_query = _MatrixAxisQuery(obs=obs_query, var=var_query)
         self._joinids = _JoinIDCache(self)
-        self._indexer = _AxisIndexer(self)
+        self._indexer = AxisIndexer(self)
         self._threadpool_: Optional[futures.ThreadPoolExecutor] = None
 
     def obs(
@@ -121,7 +121,7 @@ class ExperimentAxisQuery:
         return len(self.var_joinids())
 
     @property
-    def indexer(self) -> "_AxisIndexer":
+    def indexer(self) -> "AxisIndexer":
         """Returns a ``soma_joinid`` indexer for both ``obs`` and ``var`` axes."""
         return self._indexer
 
@@ -241,7 +241,7 @@ class ExperimentAxisQuery:
         obs_table, var_table = self._read_both_axes(column_names)
 
         x_matrices = {
-            _xname: fast_csr.read_scipy_csr(
+            _xname: _fast_csr.read_scipy_csr(
                 all_x_arrays[_xname], self.obs_joinids(), self.var_joinids()
             )
             for _xname in all_x_arrays
@@ -474,7 +474,7 @@ _Numpyable = Union[pa.Array, pa.ChunkedArray, npt.NDArray[np.int64]]
 
 
 @attrs.define
-class _AxisIndexer:
+class AxisIndexer:
     """Given a query, providing index-bulding services for obs/var axis."""
 
     query: ExperimentAxisQuery

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 from scipy import sparse
 from typing_extensions import Literal, TypedDict, assert_never
 
-from somacore import composed
-from somacore import data
-from somacore.query import axis
-
-from .fast_csr import read_scipy_csr
+from .. import composed
+from .. import data
+from . import axis
+from . import fast_csr
 
 
 class AxisColumnNames(TypedDict, total=False):
@@ -242,7 +241,7 @@ class ExperimentAxisQuery:
         obs_table, var_table = self._read_both_axes(column_names)
 
         x_matrices = {
-            _xname: read_scipy_csr(
+            _xname: fast_csr.read_scipy_csr(
                 all_x_arrays[_xname], self.obs_joinids(), self.var_joinids()
             )
             for _xname in all_x_arrays

--- a/python-spec/testing/test_query_axis.py
+++ b/python-spec/testing/test_query_axis.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 from pytest import mark
 
+import somacore
 from somacore import options
-from somacore.query import axis
 
 
 @mark.parametrize(
@@ -29,12 +29,12 @@ from somacore.query import axis
 def test_canonicalization(
     coords: options.SparseDFCoords, want: Tuple[options.SparseDFCoord, ...]
 ) -> None:
-    axq = axis.AxisQuery(coords=coords)
+    axq = somacore.AxisQuery(coords=coords)
     assert want == axq.coords
 
 
 def test_canonicalization_nparray() -> None:
-    axq = axis.AxisQuery(coords=(1, np.array([1, 2, 3])))
+    axq = somacore.AxisQuery(coords=(1, np.array([1, 2, 3])))
 
     one, arr = axq.coords
     assert one == 1
@@ -51,4 +51,4 @@ def test_canonicalization_nparray() -> None:
 )
 def test_canonicalization_bad(coords) -> None:
     with pytest.raises(TypeError):
-        axis.AxisQuery(coords=coords)
+        somacore.AxisQuery(coords=coords)


### PR DESCRIPTION
- Changes everything to use relative imports, since in a small package just using `from . import whatever` makes more sense than full-path imports.
- Makes "private modules whose exports can be used by other somacore code" vs. "private members within a single module" a bit clearer by making module names private.

Expanded details on both are in each commit’s message. The external API (provided users weren’t using the undocumented internal APIs) remains unchanged.