### PR TITLE
Rework object-creation and collection-building protocols

### DIFF
--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -5,15 +5,32 @@ members will be exported to the ``somacore`` namespace.
 """
 
 import abc
-from typing import Any, MutableMapping
+from typing import Any, MutableMapping, Optional, Type, TypeVar
 
 from typing_extensions import LiteralString
+
+from . import options
+
+_ST = TypeVar("_ST", bound="SOMAObject")
 
 
 class SOMAObject(metaclass=abc.ABCMeta):
     """A sentinel interface indicating that this type is a SOMA object."""
 
     __slots__ = ("__weakref__",)
+
+    @classmethod
+    @abc.abstractmethod
+    def open(
+        cls: Type[_ST],
+        uri: str,
+        mode: options.OpenMode = "r",
+        *,
+        context: Optional[Any] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> _ST:
+        """Opens the SOMA object at the given URL."""
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -214,6 +214,11 @@ class SimpleCollection(Collection[_ST]):
         return self._metadata
 
     @classmethod
+    def open(cls, *args, **kwargs) -> NoReturn:
+        del args, kwargs  # All unused
+        raise TypeError("SimpleCollections are in-memory only and cannot be opened.")
+
+    @classmethod
     def create(cls, *args, **kwargs) -> "SimpleCollection":
         del args, kwargs  # All unused
         # SimpleCollection is in-memory only, so just return a new empty one.

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -1,13 +1,27 @@
 import abc
-from typing import Any, Dict, Iterator, MutableMapping, Optional, Type, TypeVar
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    MutableMapping,
+    NoReturn,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
 
+import pyarrow as pa
 from typing_extensions import LiteralString
 
 from . import base
+from . import data
 from . import options
 
 _ST = TypeVar("_ST", bound=base.SOMAObject)
 """Generic type variable for any SOMA object."""
+_CT = TypeVar("_CT", bound="Collection")
+"""Any implementation of a Collection."""
 
 
 class Collection(base.SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMeta):
@@ -21,33 +35,31 @@ class Collection(base.SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMet
     __slots__ = ()
 
     @abc.abstractmethod
-    def add(
+    def add_collection(
         self,
         key: str,
-        cls: Type[_ST],
+        cls: Optional[Type[_CT]] = None,
         *,
         uri: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
-    ) -> _ST:
-        """Creates a child member of this collection and adds it.
+    ) -> _CT:
+        """Creates a new sub-collection of this collection.
 
-        This allows the creation of child objects of any type::
+        To add an existing collection as a sub-element of this collection,
+        use :meth:`set` or indexed access instead.
+
+        The type provided is used to create the skeleton of this collection
+        as in :meth:`create`. By default, this will create a basic collection::
 
             # Create a child Measurement object at the key "density"
             # with default settings.
             #
             # This creates both the backing Measurement collection, as well as
             # the necessary sub-elements to have a complete Measurement.
-            density = the_collection.create("density", somacore.Measurement)
+            density = the_collection.add_collection("density", somacore.Measurement)
 
-            # Create a child DataFrame at the key "data" with a custom URI
-            # and additional platform configuration.
-            data = the_collection.create(
-                "data",
-                somacore.DataFrame,
-                uri="file:///custom/path/to/df",
-                platform_config={"somaimpl": ...},
-            )
+            # This will create a basic Collection as a child.
+            sub_child = density.add_collection("sub_child")
 
         By default (in situations where it is possible to do so), the default
         URI used should be a relative URI with its final component as the key.
@@ -63,6 +75,57 @@ class Collection(base.SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMet
             to create this object. This may be absolute or relative.
         :param platform_config: Platform-specific configuration options used
             when creating the child.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_dataframe(
+        self,
+        key: str,
+        *,
+        uri: Optional[str] = None,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (options.SOMA_JOINID,),
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> data.DataFrame:
+        """Creates a new DataFrame as a child of this collection.
+
+        Parameters are as in :meth:`data.DataFrame.create`.
+        See :meth:`add_collection` for details about child creation.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_dense_ndarray(
+        self,
+        key: str,
+        *,
+        uri: Optional[str] = ...,
+        type: pa.DataType,
+        shape: Sequence[int],
+        platform_config: Optional[options.PlatformConfig] = ...,
+    ) -> data.DenseNDArray:
+        """Creates a new dense NDArray as a child of this collection.
+
+        Parameters are as in :meth:`data.DenseNDArray.create`.
+        See :meth:`add_collection` for details about child creation.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_sparse_ndarray(
+        self,
+        key: str,
+        *,
+        uri: Optional[str] = ...,
+        type: pa.DataType,
+        shape: Sequence[int],
+        platform_config: Optional[options.PlatformConfig] = ...,
+    ) -> data.SparseNDArray:
+        """Creates a new sparse NDArray as a child of this collection.
+
+        Parameters are as in :meth:`data.SparseNDArray.create`.
+        See :meth:`add_collection` for details about child creation.
         """
         raise NotImplementedError()
 
@@ -135,21 +198,18 @@ class SimpleCollection(Collection[_ST]):
     def metadata(self) -> Dict[str, Any]:
         return self._metadata
 
-    def add(
-        self,
-        key: str,
-        cls: Type[_ST],
-        *,
-        uri: Optional[str] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-    ) -> _ST:
-        del key, cls, uri, platform_config  # All unused
+    def add_collection(self, *args, **kwargs) -> NoReturn:
+        del args, kwargs  # All unused
         # TODO: Should we be willing to create Collection-based child elements,
         # like Measurement and Experiment?
         raise TypeError(
             "A SimpleCollection cannot create its own children;"
             " only existing SOMA objects may be added."
         )
+
+    add_dataframe = add_collection
+    add_sparse_ndarray = add_collection
+    add_dense_ndarray = add_collection
 
     def set(
         self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -34,6 +34,21 @@ class Collection(base.SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMet
 
     __slots__ = ()
 
+    @classmethod
+    @abc.abstractmethod
+    def create(
+        cls: Type[_CT],
+        uri: str,
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> _CT:
+        """Creates a new Collection at the given URI and returns it.
+
+        The collection will be returned in the opened state.
+        """
+        raise NotImplementedError()
+
     @abc.abstractmethod
     def add_collection(
         self,
@@ -197,6 +212,12 @@ class SimpleCollection(Collection[_ST]):
     @property
     def metadata(self) -> Dict[str, Any]:
         return self._metadata
+
+    @classmethod
+    def create(cls, *args, **kwargs) -> "SimpleCollection":
+        del args, kwargs  # All unused
+        # SimpleCollection is in-memory only, so just return a new empty one.
+        return cls()
 
     def add_collection(self, *args, **kwargs) -> NoReturn:
         del args, kwargs  # All unused

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -11,6 +11,10 @@ import attrs
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+from typing_extensions import Final
+
+SOMA_JOINID: Final = "soma_joinid"
+"""Global constant for the SOMA join ID."""
 
 
 class ReadPartitions:

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -11,10 +11,13 @@ import attrs
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
-from typing_extensions import Final
+from typing_extensions import Final, Literal
 
 SOMA_JOINID: Final = "soma_joinid"
 """Global constant for the SOMA join ID."""
+
+OpenMode = Literal["r", "w"]
+"""How to open a SOMA object: read or write."""
 
 
 class ReadPartitions:


### PR DESCRIPTION
This is (the specification side of) the plan for reworking the way we do creating and building complex SOMA objects. Currently, the primary model in TileDB-SOMA is to create the "leaf" objects, then work your way out to creating the "root" objects. This change is intended to better support a top-down creation model, where a user can create (for example) an Experiment, then create the members inside of it:

```python
new_exp = soma_impl.Experiment.create("uri/of/new/experiment", ...)
# new_exp is opened in write mode

new_exp.add_dataframe("obs", ...)
# an `obs` dataframe is created inside the experiment

# The user can continue to build down into the experiment,
# or any other collection they have opened in write mode.
```

It also includes a changed flow for opening SOMA objects, where the SOMA object should always refer to a known object, rather than potentially being a free-floating URI:

```python
my_coll = soma_impl.Collection.open("/path/to/whatever", ...)
# my_coll is an active, opened collection in read mode.
```

This is also intended to enable a base "smart open" function in the SOMA implementation:

```python
some_obj = soma_impl.open("/path/to/any/soma_object", ...)
# the type of some_obj is identified and an instance of the appropriate
# concrete class is returned.
```