### PR TITLE
Make `coords` for reading DataFrame and SparseNDArray optional.

### DIFF
--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -47,12 +47,12 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        coords: options.SparseDFCoords,
+        coords: Optional[options.SparseDFCoords] = None,
         column_names: Optional[Sequence[str]] = None,
         *,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,
-        result_order: options.StrOr[options.ResultOrder] = _RO_AUTO,
+        result_order: options.ResultOrderStr = _RO_AUTO,
         value_filter: Optional[str] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "ReadIter[pa.Table]":
@@ -66,6 +66,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     def write(
         self,
         values: Union[pa.RecordBatch, pa.Table],
+        *,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> None:
         """Writes values to the data store.
@@ -109,7 +110,8 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     def create(
         cls: Type[_NDT],
         uri: str,
-        *type: pa.DataType,
+        *,
+        type: pa.DataType,
         shape: Sequence[int],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
@@ -155,7 +157,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
         *,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,
-        result_order: options.StrOr[options.ResultOrder] = _RO_AUTO,
+        result_order: options.ResultOrderStr = _RO_AUTO,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> pa.Tensor:
         """Reads the specified subarray from this NDArray as a Tensor.
@@ -199,11 +201,11 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        coords: options.SparseNDCoords,
+        coords: Optional[options.SparseNDCoords] = None,
         *,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,
-        result_order: options.StrOr[options.ResultOrder] = _RO_AUTO,
+        result_order: options.ResultOrderStr = _RO_AUTO,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "SparseRead":
         """Reads a subset of the object in one or more batches.

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -5,7 +5,7 @@ SOMA types that require them, not reimplemented by the implementing package.
 """
 
 import enum
-from typing import Any, Mapping, Optional, Sequence, TypeVar, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import attrs
 import numpy as np
@@ -96,10 +96,6 @@ to individual calls. Keys are the name of a SOMA implementation, each value is
 an implementation-defined configuration structure.
 """
 
-_ET = TypeVar("_ET", bound=enum.Enum)
-StrOr = Union[_ET, str]
-"""A string, or the named enum."""
-
 
 class ResultOrder(enum.Enum):
     """The order results should be returned in."""
@@ -107,6 +103,10 @@ class ResultOrder(enum.Enum):
     AUTO = "auto"
     ROW_MAJOR = "row-major"
     COLUMN_MAJOR = "column-major"
+
+
+ResultOrderStr = Union[ResultOrder, Literal["auto", "row-major", "column-major"]]
+"""A ResultOrder, or the str representing it."""
 
 
 DenseCoord = Union[int, slice]


### PR DESCRIPTION
The TileDB implementation currently has `coords` as an optional, default-None value for reads of DataFrames and SparseNDArrays. This updates the ABCs to match that reality.