### PR TITLE
Add `close` method and context-manager operations

### DIFF
--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -68,3 +68,23 @@ class SOMAObject(metaclass=abc.ABCMeta):
     def soma_type(self) -> LiteralString:
         """A string describing the SOMA type of this object."""
         raise NotImplementedError()
+
+    # Context management
+
+    def close(self) -> None:
+        """Releases any external resources held by this object.
+
+        An implementation of close must be idempotent.
+        """
+        # Default implementation does nothing.
+
+    def __enter__(self: _ST) -> _ST:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+        super_del = getattr(super(), "__del__", lambda: None)
+        super_del()

--- a/python-spec/src/somacore/query/_eager_iter.py
+++ b/python-spec/src/somacore/query/_eager_iter.py
@@ -33,7 +33,6 @@ class EagerIterator(Iterator[_T]):
         # Ensure the threadpool is cleaned up in the case where the
         # iterator is not exhausted. For more information on __del__:
         # https://docs.python.org/3/reference/datamodel.html#object.__del__
-
+        self._cleanup()
         super_del = getattr(super(), "__del__", lambda: None)
         super_del()
-        self._cleanup()

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -211,10 +211,10 @@ class ExperimentAxisQuery(Generic[_ET]):
 
     def __del__(self) -> None:
         """Ensure that we're closed when our last ref disappears."""
+        self.close()
         # If any superclass in our MRO has a __del__, call it.
         sdel = getattr(super(), "__del__", lambda: None)
         sdel()
-        self.close()
 
     # Internals
 


### PR DESCRIPTION
This adds a `close` method to SOMAObject, which allows implementations to specify cleanup operations, and hooks it up to the context manager protocol by default.

Also cleans up other delete callsites to do our own delete work *before* calling the superclass delete.