### PR TITLE
Empty query results typing

### DIFF
--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -117,8 +117,10 @@ class _CSRAccumulator:
         nnz = sum(len(chunk[2]) for chunk in self.coo_chunks)
         index_dtype = _select_dtype(nnz)
         if nnz == 0:
-            # no way to infer matrix dtype, so use default and return empty matrix
-            empty = sparse.csr_matrix((0, 0))
+            # There is no way to infer matrix dtype, so use a default and return
+            # an empty matrix. Float32 is used as a default type, as it is most
+            # compatible with AnnData expectations.
+            empty = sparse.csr_matrix((0, 0), dtype=np.float32)
             return _CSRAccumulatorFinalResult(
                 data=empty.data,
                 indptr=empty.indptr,

--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -125,7 +125,7 @@ class _CSRAccumulator:
                 data=empty.data,
                 indptr=empty.indptr,
                 indices=empty.indices,
-                shape=(0, 0),
+                shape=self.shape,
             )
 
         # cumsum row lengths to get indptr

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -398,10 +398,10 @@ class _AxisQueryResult:
     def to_anndata(self) -> anndata.AnnData:
         """Convert to AnnData"""
         obs = self.obs.to_pandas()
-        obs.index = obs.index.map(str)
+        obs.index = obs.index.astype(str)
 
         var = self.var.to_pandas()
-        var.index = var.index.map(str)
+        var.index = var.index.astype(str)
 
         return anndata.AnnData(
             X=self.X, obs=obs, var=var, layers=(self.X_layers or None)


### PR DESCRIPTION
Several small changes to ensure that empty query results have types that are compatible with AnnData, avoiding warnings/errors from AnnData.

1. The empty matrix result in the fast CSR builder was creating an empty float64 matrix.  AnnData has a strong preference for float32, and will issue a warning on anything else.  As the actual type is relatively immaterial (it is an empty matrix), this PR changes to float32 to minimize complaints from AnnData.
2. The axis dataframes need to have an index type of str.  Previous code did not work correctly when the dataframe was empty.
3. When the resulting X is empty (nnz==0), need to ensure it has the same shape as the axis.

Fixes: single-cell-data/TileDB-SOMA#805
