### PR TITLE
[python] Enhance type-checking configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,15 @@ force_single_line = true
 known_first_party = ["somacore"]
 single_line_exclusions = ["typing", "typing_extensions"]
 
+[tool.mypy]
+check_untyped_defs = true
+enable_error_code = ["ignore-without-code"]
+warn_redundant_casts = true
+# We want to enable this but it won't work when running locally due to the
+# presence of _version.py (which invalidates the ignore, which causes an error).
+#
+#     warn_unused_ignores = true
+
 [[tool.mypy.overrides]]
 # These dependencies do not currently have canonical type stubs.
 module = ["anndata", "numba", "pandas", "pyarrow", "scipy"]

--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -165,7 +165,7 @@ class _CSRAccumulator:
         )
 
 
-@numba.jit(nopython=True, nogil=True)  # type: ignore
+@numba.jit(nopython=True, nogil=True)  # type: ignore[attr-defined]
 def _accum_row_length(
     row_length: npt.NDArray[np.int64], row_ind: npt.NDArray[np.int64]
 ) -> None:
@@ -173,7 +173,7 @@ def _accum_row_length(
         row_length[rind] += 1
 
 
-@numba.jit(nopython=True, nogil=True)  # type: ignore
+@numba.jit(nopython=True, nogil=True)  # type: ignore[attr-defined]
 def _copy_chunk_range(
     row_ind_chunk: npt.NDArray[np.signedinteger],
     col_ind_chunk: npt.NDArray[np.signedinteger],
@@ -194,7 +194,7 @@ def _copy_chunk_range(
         indptr[row] += 1
 
 
-@numba.jit(nopython=True, nogil=True)  # type: ignore
+@numba.jit(nopython=True, nogil=True)  # type: ignore[attr-defined]
 def _copy_chunklist_range(
     chunk_list: numba.typed.List,
     data: npt.NDArray[np.number],
@@ -219,7 +219,7 @@ def _copy_chunklist_range(
         )
 
 
-@numba.jit(nopython=True, nogil=True)  # type: ignore
+@numba.jit(nopython=True, nogil=True)  # type: ignore[attr-defined]
 def _finalize_indptr(indptr: npt.NDArray[np.signedinteger]):
     prev = 0
     for r in range(len(indptr)):

--- a/python-spec/testing/test_collection.py
+++ b/python-spec/testing/test_collection.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 from somacore import collection
 from somacore import experiment
@@ -10,8 +11,8 @@ class SimpleCollectionTest(unittest.TestCase):
         # Since the SimpleCollection implementation is straightforward this is
         # just to ensure that we actually fulfill everything.
 
-        coll = collection.SimpleCollection()
-        entry_a = collection.SimpleCollection()
+        coll = collection.SimpleCollection[Any]()
+        entry_a = collection.SimpleCollection[Any]()
         coll["a"] = entry_a
         self.assertIs(entry_a, coll["a"])
         del coll["a"]


### PR DESCRIPTION
- Require setting codes on type-ignore comments.
- Warn on unnecessary typecasts.
- Check functions without type information.