### PR TITLE
Pull "ephemeral" collections into their own module.

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -4,14 +4,24 @@ Types will be defined in their own modules and then imported here for a single
 unified namespace.
 """
 
+# __init__ files, used strictly for re-exporting, are the exception to the
+# "import modules only" style used in somacore.
+
 from typing import Tuple, Union
 
-from . import base
-from . import collection
-from . import data
-from . import options
-from . import query
-from .query import axis
+from .base import SOMAObject
+from .collection import Collection
+from .data import DataFrame
+from .data import DenseNDArray
+from .data import NDArray
+from .data import ReadIter
+from .data import SparseNDArray
+from .data import SparseRead
+from .options import BatchSize
+from .options import IOfN
+from .options import ResultOrder
+from .query import AxisQuery
+from .query import ExperimentAxisQuery
 
 try:
     # This trips up mypy since it's a generated file:
@@ -23,37 +33,19 @@ except ImportError:
     __version__ = "0.0.0.dev+invalid"
     __version_tuple__ = (0, 0, 0, "dev", "invalid")
 
-SOMAObject = base.SOMAObject
-
-Collection = collection.Collection
-SimpleCollection = collection.SimpleCollection
-
-DataFrame = data.DataFrame
-NDArray = data.NDArray
-DenseNDArray = data.DenseNDArray
-SparseNDArray = data.SparseNDArray
-ReadIter = data.ReadIter
-SparseRead = data.SparseRead
-
-IOfN = options.IOfN
-BatchSize = options.BatchSize
-ResultOrder = options.ResultOrder
-
-AxisQuery = axis.AxisQuery
-ExperimentAxisQuery = query.ExperimentAxisQuery
 
 __all__ = (
     "SOMAObject",
     "Collection",
-    "SimpleCollection",
     "DataFrame",
-    "NDArray",
     "DenseNDArray",
-    "SparseNDArray",
+    "NDArray",
     "ReadIter",
+    "SparseNDArray",
     "SparseRead",
-    "IOfN",
     "BatchSize",
+    "IOfN",
     "ResultOrder",
     "AxisQuery",
+    "ExperimentAxisQuery",
 )

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -1,15 +1,5 @@
 import abc
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    MutableMapping,
-    NoReturn,
-    Optional,
-    Sequence,
-    Type,
-    TypeVar,
-)
+from typing import Any, MutableMapping, Optional, Sequence, Type, TypeVar
 
 import pyarrow as pa
 
@@ -181,75 +171,3 @@ class Collection(base.SOMAObject, MutableMapping[str, _ST], metaclass=abc.ABCMet
             If ``False``, will always use an absolute URI.
         """
         raise NotImplementedError()
-
-
-class SimpleCollection(Collection[_ST]):
-    """A memory-backed SOMA Collection for ad-hoc collection building.
-
-    This Collection implementation exists purely in memory. It can be used to
-    build ad-hoc SOMA Collections for one-off analyses, and to combine SOMA
-    datasets from different sources that cannot be added to a Collection that
-    is represented in storage.
-
-    Entries added to this Collection are not "owned" by the collection; their
-    lifecycle is still dictated by the place they were opened from. This
-    collection has no ``context`` and ``close``ing it does nothing.
-    """
-
-    def __init__(self, *args: Any, **kwargs: _ST):
-        """Creates a new Collection.
-
-        Arguments and kwargs are provided as in the ``dict`` constructor.
-        """
-        self._entries: Dict[str, _ST] = dict(*args, **kwargs)
-        self._metadata: Dict[str, Any] = {}
-
-    @property
-    def uri(self) -> str:
-        return f"somacore:simple-collection:{id(self):x}"
-
-    @property
-    def metadata(self) -> Dict[str, Any]:
-        return self._metadata
-
-    @classmethod
-    def open(cls, *args, **kwargs) -> NoReturn:
-        del args, kwargs  # All unused
-        raise TypeError("SimpleCollections are in-memory only and cannot be opened.")
-
-    @classmethod
-    def create(cls, *args, **kwargs) -> "SimpleCollection":
-        del args, kwargs  # All unused
-        # SimpleCollection is in-memory only, so just return a new empty one.
-        return cls()
-
-    def add_new_collection(self, *args, **kwargs) -> NoReturn:
-        del args, kwargs  # All unused
-        # TODO: Should we be willing to create Collection-based child elements,
-        # like Measurement and Experiment?
-        raise TypeError(
-            "A SimpleCollection cannot create its own children;"
-            " only existing SOMA objects may be added."
-        )
-
-    add_new_dataframe = add_new_collection
-    add_new_sparse_ndarray = add_new_collection
-    add_new_dense_ndarray = add_new_collection
-
-    def set(
-        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
-    ) -> None:
-        del use_relative_uri  # Ignored.
-        self._entries[key] = value
-
-    def __getitem__(self, key: str) -> _ST:
-        return self._entries[key]
-
-    def __delitem__(self, key: str) -> None:
-        del self._entries[key]
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._entries)
-
-    def __len__(self) -> int:
-        return len(self._entries)

--- a/python-spec/src/somacore/ephemeral/__init__.py
+++ b/python-spec/src/somacore/ephemeral/__init__.py
@@ -1,0 +1,16 @@
+"""In-memory-only implementations of SOMA types.
+
+These are meant for testing and exploration, where a user may want to do an
+ad-hoc analysis of multiple datasets without having to create a stored
+Collection.
+"""
+
+from .collections import Collection
+from .collections import Experiment
+from .collections import Measurement
+
+__all__ = (
+    "Collection",
+    "Experiment",
+    "Measurement",
+)

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -31,7 +31,7 @@ class Collection(collection.Collection[_ST]):
 
     @property
     def uri(self) -> str:
-        return f"somacore:simple-collection:{id(self):x}"
+        return f"somacore:ephemeral-collection:{id(self):x}"
 
     @property
     def metadata(self) -> Dict[str, Any]:
@@ -40,12 +40,14 @@ class Collection(collection.Collection[_ST]):
     @classmethod
     def open(cls, *args, **kwargs) -> NoReturn:
         del args, kwargs  # All unused
-        raise TypeError("SimpleCollections are in-memory only and cannot be opened.")
+        raise TypeError(
+            "Ephemeral collections are in-memory only and cannot be opened."
+        )
 
     @classmethod
     def create(cls, *args, **kwargs) -> "Collection":
         del args, kwargs  # All unused
-        # SimpleCollection is in-memory only, so just return a new empty one.
+        # ThisCollection is in-memory only, so just return a new empty one.
         return cls()
 
     def add_new_collection(self, *args, **kwargs) -> NoReturn:
@@ -53,7 +55,7 @@ class Collection(collection.Collection[_ST]):
         # TODO: Should we be willing to create Collection-based child elements,
         # like Measurement and Experiment?
         raise TypeError(
-            "A SimpleCollection cannot create its own children;"
+            "An ephemeral Collection cannot create its own children;"
             " only existing SOMA objects may be added."
         )
 

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -1,0 +1,88 @@
+from typing import Any, Dict, Iterator, NoReturn, Optional, TypeVar
+
+from .. import base
+from .. import collection
+from .. import experiment
+from .. import measurement
+
+_ST = TypeVar("_ST", bound=base.SOMAObject)
+
+
+class Collection(collection.Collection[_ST]):
+    """A memory-backed SOMA Collection for ad-hoc collection building.
+
+    This Collection implementation exists purely in memory. It can be used to
+    build ad-hoc SOMA Collections for one-off analyses, and to combine SOMA
+    datasets from different sources that cannot be added to a Collection that
+    is represented in storage.
+
+    Entries added to this Collection are not "owned" by the collection; their
+    lifecycle is still dictated by the place they were opened from. This
+    collection has no ``context`` and ``close``ing it does nothing.
+    """
+
+    def __init__(self, *args: Any, **kwargs: _ST):
+        """Creates a new Collection.
+
+        Arguments and kwargs are provided as in the ``dict`` constructor.
+        """
+        self._entries: Dict[str, _ST] = dict(*args, **kwargs)
+        self._metadata: Dict[str, Any] = {}
+
+    @property
+    def uri(self) -> str:
+        return f"somacore:simple-collection:{id(self):x}"
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return self._metadata
+
+    @classmethod
+    def open(cls, *args, **kwargs) -> NoReturn:
+        del args, kwargs  # All unused
+        raise TypeError("SimpleCollections are in-memory only and cannot be opened.")
+
+    @classmethod
+    def create(cls, *args, **kwargs) -> "Collection":
+        del args, kwargs  # All unused
+        # SimpleCollection is in-memory only, so just return a new empty one.
+        return cls()
+
+    def add_new_collection(self, *args, **kwargs) -> NoReturn:
+        del args, kwargs  # All unused
+        # TODO: Should we be willing to create Collection-based child elements,
+        # like Measurement and Experiment?
+        raise TypeError(
+            "A SimpleCollection cannot create its own children;"
+            " only existing SOMA objects may be added."
+        )
+
+    add_new_dataframe = add_new_collection
+    add_new_sparse_ndarray = add_new_collection
+    add_new_dense_ndarray = add_new_collection
+
+    def set(
+        self, key: str, value: _ST, *, use_relative_uri: Optional[bool] = None
+    ) -> None:
+        del use_relative_uri  # Ignored.
+        self._entries[key] = value
+
+    def __getitem__(self, key: str) -> _ST:
+        return self._entries[key]
+
+    def __delitem__(self, key: str) -> None:
+        del self._entries[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+class Measurement(measurement.Measurement, Collection):  # type: ignore[misc]
+    """An in-memory Collection with Measurement semantics."""
+
+
+class Experiment(experiment.Experiment, Collection):  # type: ignore[misc]
+    """An in-memory Collection with Experiment semantics."""

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -63,7 +63,3 @@ class Experiment(MutableMapping[str, _ST]):
             obs_query=obs_query or query.AxisQuery(),
             var_query=var_query or query.AxisQuery(),
         )
-
-
-class SimpleExperiment(Experiment, collection.SimpleCollection):  # type: ignore[misc]
-    """An in-memory Collection with Experiment semantics."""

--- a/python-spec/src/somacore/measurement.py
+++ b/python-spec/src/somacore/measurement.py
@@ -68,7 +68,3 @@ class Measurement(MutableMapping[str, _ST]):
 
     This is indexed by ``[varid_1, varid_2]``.
     """
-
-
-class SimpleMeasurement(Measurement, collection.SimpleCollection):  # type: ignore[misc]
-    """An in-memory Collection with Measurement semantics."""

--- a/python-spec/testing/test_collection.py
+++ b/python-spec/testing/test_collection.py
@@ -1,18 +1,16 @@
 import unittest
 from typing import Any
 
-from somacore import collection
-from somacore import experiment
-from somacore import measurement
+from somacore import ephemeral
 
 
-class SimpleCollectionTest(unittest.TestCase):
+class EphemeralCollectionTest(unittest.TestCase):
     def test_basic(self):
         # Since the SimpleCollection implementation is straightforward this is
         # just to ensure that we actually fulfill everything.
 
-        coll = collection.SimpleCollection[Any]()
-        entry_a = collection.SimpleCollection[Any]()
+        coll = ephemeral.Collection[Any]()
+        entry_a = ephemeral.Collection[Any]()
         coll["a"] = entry_a
         self.assertIs(entry_a, coll["a"])
         del coll["a"]
@@ -28,8 +26,8 @@ class SimpleCollectionTest(unittest.TestCase):
         # and nothing else.
         # If these were any other Mapping type, they would be `__eq__` here,
         # since they both have the same (i.e., no) elements.
-        coll = collection.SimpleCollection[Any]()
-        coll_2 = collection.SimpleCollection[Any]()
+        coll = ephemeral.Collection[Any]()
+        coll_2 = ephemeral.Collection[Any]()
         self.assertNotEqual(coll, coll_2)
         both = frozenset((coll, coll_2))
         self.assertIn(coll, both)
@@ -38,7 +36,7 @@ class SimpleCollectionTest(unittest.TestCase):
     def test_method_resolution_order(self):
         # Ensures that constant definitions interact correctly with the MRO.
 
-        m = measurement.SimpleMeasurement()
+        m = ephemeral.Measurement()
         self.assertEqual("SOMAMeasurement", m.soma_type)
-        exp = experiment.SimpleExperiment()
+        exp = ephemeral.Experiment()
         self.assertEqual("SOMAExperiment", exp.soma_type)

--- a/python-spec/testing/test_collection.py
+++ b/python-spec/testing/test_collection.py
@@ -6,8 +6,8 @@ from somacore import ephemeral
 
 class EphemeralCollectionTest(unittest.TestCase):
     def test_basic(self):
-        # Since the SimpleCollection implementation is straightforward this is
-        # just to ensure that we actually fulfill everything.
+        # Since the ephemeral Collection implementation is straightforward,
+        # this is just to ensure that we actually fulfill everything.
 
         coll = ephemeral.Collection[Any]()
         entry_a = ephemeral.Collection[Any]()

--- a/python-spec/testing/test_mixin.py
+++ b/python-spec/testing/test_mixin.py
@@ -1,14 +1,14 @@
 import unittest
 
 from somacore import _mixin
-from somacore import collection
+from somacore import ephemeral
 
 
 class TestItem(unittest.TestCase):
     def test_get(self):
         the_a = _mixin.item(str)
 
-        class ItemHaver(collection.SimpleCollection):
+        class ItemHaver(ephemeral.Collection):
             a = the_a
             b = _mixin.item(int, "base_b")
 


### PR DESCRIPTION
The meaning and usage of the various `SimpleWhatever` collections was unclear with them colocated with the abstract implementation. Moving them to their own `ephemeral` module and not having them in the main `somacore` namespace will make them less attractive. They still have value in being the most basic possible implementation of a collection, and are useful in tests for this package.

In the process of removing the `SimpleCollection` export from the package root, also changes the `__init__.py` to just import module members rather than the module itself. Since this is at the top level and is exclusively for re-export, this does not have the same potential circular dependency problems as doing so within internal modules, while reducing repetition and the possibility of errors.