### PR TITLE
Add support for str and bytes in AxisQuery

### DIFF
--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -18,6 +18,10 @@ def _canonicalize_coords(
     """
     if in_coords is None:
         return (slice(None),)
+    if not isinstance(in_coords, Sequence):
+        raise TypeError(
+            f"query coordinates must be a sequence, not a single {type(in_coords)}"
+        )
     if not _is_normal_sequence(in_coords):
         raise TypeError(
             "query coordinates must be a normal sequence, not `str` or `bytes`."
@@ -28,10 +32,10 @@ def _canonicalize_coords(
 def _canonicalize_coord(coord: options.SparseDFCoord) -> options.SparseDFCoord:
     """Validates a single coordinate, freezing mutable sequences."""
     if coord is None or isinstance(
-        coord, (int, slice, pa.Array, pa.ChunkedArray, np.ndarray)
+        coord, (bytes, int, slice, str, pa.Array, pa.ChunkedArray, np.ndarray)
     ):
         return coord
-    if _is_normal_sequence(coord):
+    if isinstance(coord, Sequence):
         # We're trusting here that the elements of the user's sequence are
         # appropriate. If this is not the case, it will raise down the line.
         return tuple(coord)

--- a/python-spec/testing/test_query_axis.py
+++ b/python-spec/testing/test_query_axis.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Any, Tuple
 
 import numpy as np
 import pytest
@@ -14,21 +14,10 @@ from somacore import options
         ((slice(1, 10),), (slice(1, 10),)),
         ([0, 1, 2], (0, 1, 2)),
         ((slice(None), [0, 88, 1001]), (slice(None), (0, 88, 1001))),
-        pytest.param(
-            ("string-coord",),
-            ("string-coord",),
-            marks=mark.xfail(reason="strings not supported yet"),
-        ),
-        pytest.param(
-            (b"bytes-coord",),
-            (b"bytes-coord",),
-            marks=mark.xfail(reason="bytes not supported yet"),
-        ),
+        (("string-coord", [b"lo", b"hi"]), ("string-coord", (b"lo", b"hi"))),
     ],
 )
-def test_canonicalization(
-    coords: options.SparseDFCoords, want: Tuple[options.SparseDFCoord, ...]
-) -> None:
+def test_canonicalization(coords: Any, want: Tuple[options.SparseDFCoord, ...]) -> None:
     axq = somacore.AxisQuery(coords=coords)
     assert want == axq.coords
 
@@ -47,6 +36,7 @@ def test_canonicalization_nparray() -> None:
         ("forbid bare strings",),
         (b"forbid bare byteses",),
         ([1, 1.5, 2],),
+        (999,),
     ],
 )
 def test_canonicalization_bad(coords) -> None:


### PR DESCRIPTION
Because our backend now supports string and bytes queries [1], we no longer need to reject them at the input stage. Also adds more tests.

[1]: https://github.com/single-cell-data/TileDB-SOMA/pull/861

---

Related to: https://github.com/single-cell-data/TileDB-SOMA/issues/419