### PR TITLE
Rework and enhance type hierarchy and generics

### DIFF
--- a/python-spec/src/somacore/measurement.py
+++ b/python-spec/src/somacore/measurement.py
@@ -1,6 +1,6 @@
 """Implementations of the composed SOMA data types."""
 
-from typing import MutableMapping, TypeVar
+from typing import Generic, TypeVar
 
 from typing_extensions import Final
 
@@ -9,28 +9,47 @@ from . import base
 from . import collection
 from . import data
 
-_ST = TypeVar("_ST", bound=base.SOMAObject)
+_DF = TypeVar("_DF", bound=data.DataFrame)
+"""A particular implementation of DataFrame."""
+_NDColl = TypeVar("_NDColl", bound=collection.Collection[data.NDArray])
+"""A particular implementation of a collection of NDArrays."""
+_DenseNDColl = TypeVar("_DenseNDColl", bound=collection.Collection[data.DenseNDArray])
+"""A particular implementation of a collection of DenseNDArrays."""
+_SparseNDColl = TypeVar(
+    "_SparseNDColl", bound=collection.Collection[data.SparseNDArray]
+)
+"""A particular implementation of a collection of SparseNDArrays."""
+_RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
+"""The root SomaObject type of the implementation."""
 
 
-class Measurement(MutableMapping[str, _ST]):
+class Measurement(
+    collection.BaseCollection[_RootSO],
+    Generic[_DF, _NDColl, _DenseNDColl, _SparseNDColl, _RootSO],
+):
     """A set of observations defined by a DataFrame, with measurements."""
 
-    # This class is implemented as a mixin to be used with SOMA classes:
+    # This class is implemented as a mixin to be used with SOMA classes.
+    # For example, a SOMA implementation would look like this:
     #
-    #     # in a SOMA implementation:
-    #     class Measurement(somacore.Measurement, ImplBaseCollection):
-    #         pass
-    #
-    # Measurement should always appear *first* in the base class list.
-    # MutableMapping is listed as the parent type instead of Collection here
-    # to avoid the interpreter being unable to pick the right base class:
-    #
-    #     TypeError: multiple bases have instance lay-out conflict
+    #     # This type-ignore comment will always be needed due to limitations
+    #     # of type annotations; it is (currently) expected.
+    #     class Measurement(  # type: ignore[type-var]
+    #         ImplBaseCollection[ImplSOMAObject],
+    #         somacore.Measurement[
+    #             ImplDataFrame,                      # _DF
+    #             ImplCollection[ImplNDArray],        # _NDColl
+    #             ImplCollection[ImplDenseNDArray],   # _DenseNDColl
+    #             ImplCollection[ImplSparseNDArray],  # _SparseNDColl
+    #             ImplSOMAObject,                     # _RootSO
+    #         ],
+    #     ):
+    #         ...
 
     __slots__ = ()
-    soma_type: Final = "SOMAMeasurement"
+    soma_type: Final = "SOMAMeasurement"  # type: ignore[misc]
 
-    var = _mixin.item(data.DataFrame)
+    var = _mixin.item[_DF]()
     """Primary annotations on the variable axis for vars on this meansurement.
 
     This annotates _columns_ of the ``X`` arrays. The contents of the
@@ -38,32 +57,32 @@ class Measurement(MutableMapping[str, _ST]):
     All variables for this measurement _must_ be defined in this dataframe.
     """
 
-    X = _mixin.item(collection.Collection[data.NDArray])
+    X = _mixin.item[_NDColl]()
     """A collection of matrices containing feature values.
 
     Each matrix is indexed by ``[obsid, varid]``. Sparse and dense 2D arrays may
     both be used in any combination in ``X``.
     """
 
-    obsm = _mixin.item(collection.Collection[data.DenseNDArray])
+    obsm = _mixin.item[_DenseNDColl]()
     """Matrices containing annotations of each ``obs`` row.
 
     This has the same shape as ``obs`` and is indexed with ``obsid``.
     """
 
-    obsp = _mixin.item(collection.Collection[data.SparseNDArray])
+    obsp = _mixin.item[_SparseNDColl]()
     """Matrices containg pairwise annotations of each ``obs`` row.
 
     This is indexed by ``[obsid_1, obsid_2]``.
     """
 
-    varm = _mixin.item(collection.Collection[data.DenseNDArray])
+    varm = _mixin.item[_DenseNDColl]()
     """Matrices containing annotations of each ``var`` row.
 
     This has the same shape as ``var`` and is indexed with ``varid``.
     """
 
-    varp = _mixin.item(collection.Collection[data.SparseNDArray])
+    varp = _mixin.item[_SparseNDColl]()
     """Matrices containg pairwise annotations of each ``var`` row.
 
     This is indexed by ``[varid_1, varid_2]``.

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -36,11 +36,11 @@ class AxisColumnNames(TypedDict, total=False):
     """var columns to use. All columns if ``None`` or not present."""
 
 
-_ET = TypeVar("_ET", bound="_Experimentish")
+_Exp = TypeVar("_Exp", bound="_Experimentish")
 """TypeVar for the concrete type of an experiment-like object."""
 
 
-class ExperimentAxisQuery(Generic[_ET]):
+class ExperimentAxisQuery(Generic[_Exp]):
     """Axis-based query against a SOMA Experiment. [lifecycle: experimental]
 
     ExperimentAxisQuery allows easy selection and extraction of data from a
@@ -73,7 +73,7 @@ class ExperimentAxisQuery(Generic[_ET]):
 
     def __init__(
         self,
-        experiment: _ET,
+        experiment: _Exp,
         measurement_name: str,
         *,
         obs_query: axis.AxisQuery = axis.AxisQuery(),
@@ -531,5 +531,10 @@ def _to_numpy(it: _Numpyable) -> np.ndarray:
 class _Experimentish(Protocol):
     """The API we need from an Experiment."""
 
-    ms: Mapping[str, measurement.Measurement]
-    obs: data.DataFrame
+    @property
+    def ms(self) -> Mapping[str, measurement.Measurement]:
+        ...
+
+    @property
+    def obs(self) -> data.DataFrame:
+        ...


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SOMA/issues/638 and https://github.com/single-cell-data/TileDB-SOMA/issues/540

- Pulls basic collection impl into `BaseCollection`, allowing `Collection` to add the semantics of "no semantics". This mirrors the implementation in `tiledbsoma`.
- Makes `Measurement` and `Experiment` inherit from `BaseCollection`. Previous problems with this were due to missing `__slots__`.
- Adds generic parameters to `Measurement` and `Experiment` that allow implementations to specify the exact types they provide, saving a lot of `cast`ing down the road.
- Renames lots of TypeVars to be clearer about their purpose.
- Adds overloads to `add_new_collection` for better type inference.
- Tightens `_Experimentish` to only expect read accessors, not writers.

While these new changes add a bunch of generic slots to the base collection types and experiments and measurements, the experience from the perspective of a SOMA library user will be roughly the same. That is to say, it's a little scary here, but the end user will still see `theimpl.Collection[ElementType]`. Type inference when using composed objects is better as well:

    some_exp = theimpl.Experiment.open(...)

    obs = some_exp.obs
    reveal_type(obs)
    # BEFORE: somacore.DataFrame
    #         (i.e., the type system doesn't know what implementation
    #         of the abstract DataFrame this is; it only knows about
    #         the bare minimum DataFrame properties)
    # AFTER:  theimpl.DataFrame

    ms = some_exp.ms
    reveal_type(ms)
    # BEFORE: somacore.Collection[somacore.Measurement]
    # AFTER:  theimpl.Collection[theimpl.Measurement]

    some_meas = ms["whatever"]
    reveal_type(ms)
    # BEFORE: somacore.Measurement
    # AFTER:  theimpl.Measurement

    some_meas.X
    reveal_type(ms)
    # BEFORE: somacore.Collection[somacore.NDArray]
    # AFTER:  theimpl.Collection[theimpl.NDArray]

There is no change at runtime; the actual types of the objects remain the same, but autocompletion, type checking, and other tooling has a *much* better idea of what is going on.

---

To show what this looks like on the `tiledbsoma` side, the diff is pretty small, but [the key part is in io.py](https://github.com/single-cell-data/TileDB-SOMA/commit/3ad34022416dfa5e55e4df557c428a9993d937a6#diff-c4a63186d94cc786d00d4cde2d8716655f99d92842410074b0bc93b750bb5fed), where the `cast(tiledbsoma.Measurement, ms[whatever])` no longer needs to happen, since the type system already knows it’s a `tiledbsoma.Measurement`. While that is the only change there *specifically*, there will be corresponding improvements in user code.

And just to reiterate: **runtime behavior is identical**, and any code which works now will continue to work, but static type inference is significantly improved.