### PR TITLE
Export `AxisColumnNames`

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -20,6 +20,7 @@ from .data import SparseRead
 from .options import BatchSize
 from .options import IOfN
 from .options import ResultOrder
+from .query import AxisColumnNames
 from .query import AxisQuery
 from .query import ExperimentAxisQuery
 
@@ -46,6 +47,7 @@ __all__ = (
     "BatchSize",
     "IOfN",
     "ResultOrder",
+    "AxisColumnNames",
     "AxisQuery",
     "ExperimentAxisQuery",
 )

--- a/python-spec/src/somacore/query/__init__.py
+++ b/python-spec/src/somacore/query/__init__.py
@@ -2,6 +2,11 @@ from . import axis
 from . import query
 
 ExperimentAxisQuery = query.ExperimentAxisQuery
+AxisColumnNames = query.AxisColumnNames
 AxisQuery = axis.AxisQuery
 
-__all__ = ("ExperimentAxisQuery",)
+__all__ = (
+    "ExperimentAxisQuery",
+    "AxisColumnNames",
+    "AxisQuery",
+)


### PR DESCRIPTION
This is the `somacore` have of the solution for https://github.com/single-cell-data/TileDB-SOMA/issues/791.

Once this is in place and a `python-v0.0.0a11` is tagged, we can have `tiledbsoma` re-export `AxisColumnNames`.