### PR TITLE
[spec] Specify object lifecycle and related operations

### DIFF
--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -415,7 +415,7 @@ In addition, SOMACollection supports operations to manage the contents of the co
 
 A SOMA collection also manages the lifecycle of objects directly instantiated by it.
 Objects accessed via getting a Collection element, or objects created with one of the <code>add*new*<var>object_type</var></code> methods are considered "owned" by the collection.
-This allows all the objects to be automatically closed together by [the collection's close operation](#operation-close-collection-types).
+All such objects will be automatically closed together by [the collection's close operation](#operation-close-collection-types).
 
 ### Operation: create() (Collection types)
 

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -124,13 +124,16 @@ SOMACollection is an unordered, `string`-keyed map of values. Values may be any 
 
 #### Collection entry URIs
 
-Collections refer to their components by URI.
+Collections refer to their elements by URI.
 A collection may store its reference to an element by **absolute** URI or **relative** URI.
 
 A reference to an **absolute** URI is, as the name implies, absolute.
+This means that the collection stores the full URI of the element.
 When the backing storage of the collection itself is moved, absolute URI references do not change.
 
 A collection can also refer to sub-paths of itself by **relative** URI.
+This means that the collection's elements are stored as suffixes of the collection's path; for instance for a collection at `backend://host/dataset`, the name `child` would refer to `backend://host/dataset/child`.
+This applies both to truly hierarchical systems (like POSIX filesystems) and systems that are technically non-hierarchical but can emulate a hierarchical namespace, like Amazon S3 or Google Cloud Storage.
 If the entire directory storing a collection and a child referred to by relative URI is moved, the relative URI references now refer to the changed base URI.
 While the term "relative" is used, only **child** URIs are supported as relative URIs; relative paths like `../sibling-path/sub-entry` are not supported.
 
@@ -176,11 +179,11 @@ When `file:///soma-dataset/old-data/the-collection` is opened, the URIs will be 
 - `absolute`: `file:///soma-dataset/collection/abspath`
   (This resolved URI is the same as before. However, the data is no longer at this location; attempting to access this element will fail.)
 - `external-absolute`: `file:///soma-dataset/more-data/other-data`
-  (This URI still points to the same data.)
+  (This URI is identical and still points to the same data.)
 - `relative`: `file:///soma-dataset/old-data/the-collection/relpath`
   (This URI resolves differently and still points to the same data even after it has been moved.)
 
-In general, absolute and relative URIs can both be used interchangeably.
+In general, absolute and relative URIs can both be used interchangeably within the same collection (as in the example above).
 However, in certain situations, an implementation may support only absolute or relative URIs.
 For instance, a purely filesystem-based implementation may support only relative URIs, or a non-hierarchichal storage backend may support only absolute URIs.
 

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -305,7 +305,7 @@ A SOMA object is instantiated by **opening** a provided URI, in one of [_read_ o
 The opened object can be manipulated (pursuant to its open state) until it is **closed**, at which point any further calls which attempt to access or modifying backing data will fail (again, akin to a file object).
 
 SOMA objects are open for **exclusively** reading or writing.
-When a SOMA object is open for writing, only metadata, the schema, and information directly derived from the schema may be read.
+When a SOMA object is open for writing, the `read()` method cannot be called. However, its metadata, its schema, and information directly derived from the schema may be inspected.
 Additionally, for collection objects, the members of the collection are also accessible when the collection is open in write mode.
 For example:
 
@@ -461,7 +461,7 @@ Summary of operations on a SOMACollection, where `ValueType` is any SOMA-defined
 | Operation     | Description                                                              |
 | ------------- | ------------------------------------------------------------------------ |
 | close()       | Closes this SOMACollection and other objects whose lifecycle it manages. |
-| get soma_type | Returns the constant "SOMACollection"                                    |
+| get soma_type | Returns the constant "SOMACollection".                                   |
 
 In addition, SOMACollection supports operations to manage the contents of the collection:
 
@@ -553,7 +553,7 @@ Parameters:
 
 ### Operation: add_new\_<var>object_type</var>
 
-Each <code>add_new\_<var>object_type</var></code> method creates a new SOMA dataset in storage, adds it to the collection, and returns it to the user. The newly-created entry has the same `context` value as the existing collection and is [owned by the current collection](#operation-close-collection-types).
+Each <code>add_new\_<var>object_type</var></code> method creates a new SOMA dataset in storage, adds it to the collection (with the same semantics as the `create` operation), and returns it to the user. The newly-created entry has the same `context` value as the existing collection and is [owned by the current collection](#operation-close-collection-types).
 
 ```
 add_new_dataframe(string key, string uri = "", ...) -> SOMADataFrame

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -719,7 +719,6 @@ Summary:
 ```
 read(
     coords,
-    batch_size,
     partitions,
     result_order,
     platform_config,
@@ -727,7 +726,7 @@ read(
 ```
 
 - coords - per-dimension slice (see the [indexing and slicing](#indexing-and-slicing) section below), expressed as a per-dimension list of scalar or range.
-- partition - an optional [`SOMAReadPartitions`](#SOMAReadPartitions) to partition read operations.
+- partitions - an optional [`SOMAReadPartitions`](#SOMAReadPartitions) to partition read operations.
 - result_order - a [`ResultOrder`](#resultorder) specifying the order of read results.
 - [platform_config](#platform-specific-configuration) - optional storage-engine specific configuration
 


### PR DESCRIPTION
This formalizes the object lifecycle and the various creation, opening, and closing methods we are already using in the tiledbsoma Python implementation.

See #107.