### PR TITLE
[python] Add missing lifecycle methods and expand docstrings

### DIFF
--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -27,7 +27,14 @@ class SOMAObject(metaclass=abc.ABCMeta):
         context: Optional[Any] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
-        """Opens the SOMA object at the given URL."""
+        """Opens the SOMA object of this type at the given URI.
+
+        :param uri: The URI of the object to open.
+        :param mode: The mode to open this in, either `r` or `w`.
+        :param context: The Context value to use when opening the object.
+        :param platform_config: Platform configuration options specific to
+            this open operation.
+        """
         raise NotImplementedError()
 
     @property
@@ -59,6 +66,18 @@ class SOMAObject(metaclass=abc.ABCMeta):
         and writes to it (provided the object is opened) are reflected in
         storage.
         """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def mode(self) -> options.OpenMode:
+        """Returns the mode this object was opened in."""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def closed(self) -> bool:
+        """Returns True if this object has been closed; False if still open."""
         raise NotImplementedError()
 
     soma_type: ClassVar[LiteralString]

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -13,7 +13,7 @@ from . import options
 
 
 class SOMAObject(metaclass=abc.ABCMeta):
-    """A sentinel interface indicating that this type is a SOMA object."""
+    """The base type for all SOMA objects, containing common behaviors."""
 
     __slots__ = ("__weakref__",)
 
@@ -28,6 +28,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
         """Opens the SOMA object of this type at the given URI.
+        [lifecycle: experimental]
 
         :param uri: The URI of the object to open.
         :param mode: The mode to open this in, either `r` or `w`.
@@ -40,12 +41,13 @@ class SOMAObject(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def uri(self) -> str:
-        """Returns the URI of this SOMA object."""
+        """Returns the URI of this SOMA object. [lifecycle: experimental]"""
         raise NotImplementedError()
 
     @property
     def context(self) -> Any:
         """A value storing implementation-specific configuration information.
+        [lifecycle: experimental]
 
         This contains long-lived (i.e., not call-specific) information that is
         used by the SOMA implementation to access storage. This may include
@@ -60,7 +62,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def metadata(self) -> MutableMapping[str, Any]:
-        """The metadata of this SOMA object.
+        """The metadata of this SOMA object. [lifecycle: experimental]
 
         The returned value directly references the stored metadata; reads from
         and writes to it (provided the object is opened) are reflected in
@@ -71,13 +73,17 @@ class SOMAObject(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def mode(self) -> options.OpenMode:
-        """Returns the mode this object was opened in."""
+        """Returns the mode this object was opened in, either ``r`` or ``w``.
+        [lifecycle: experimental]
+        """
         raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def closed(self) -> bool:
-        """Returns True if this object has been closed; False if still open."""
+        """Returns True if this object has been closed; False if still open.
+        [lifecycle: experimental]
+        """
         raise NotImplementedError()
 
     soma_type: ClassVar[LiteralString]
@@ -93,6 +99,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
 
     def close(self) -> None:
         """Releases any external resources held by this object.
+        [lifecycle: experimental]
 
         An implementation of close must be idempotent.
         """

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -18,6 +18,7 @@ class BaseCollection(
     base.SOMAObject, MutableMapping[str, _Elem], metaclass=abc.ABCMeta
 ):
     """A generic string-keyed collection of :class:`SOMAObject`s.
+    [lifecycle: experimental]
 
     The generic type specifies what type the Collection may contain. At its
     most generic, a Collection may contain any SOMA object, but a subclass
@@ -36,6 +37,7 @@ class BaseCollection(
         context: Optional[Any] = None,
     ) -> Self:
         """Creates a new collection of this type at the given URI.
+        [lifecycle: experimental]
 
         The collection will be returned opened for writing.
         """
@@ -81,6 +83,7 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "BaseCollection":
         """Creates a new sub-collection of this collection.
+        [lifecycle: experimental]
 
         To add an existing collection as a sub-element of this collection,
         use :meth:`set` or indexed access instead.
@@ -131,6 +134,7 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.DataFrame:
         """Creates a new DataFrame as a child of this collection.
+        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.DataFrame.create`.
         See :meth:`add_new_collection` for details about child creation.
@@ -148,6 +152,7 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.DenseNDArray:
         """Creates a new dense NDArray as a child of this collection.
+        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.DenseNDArray.create`.
         See :meth:`add_new_collection` for details about child creation.
@@ -165,6 +170,7 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.SparseNDArray:
         """Creates a new sparse NDArray as a child of this collection.
+        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.SparseNDArray.create`.
         See :meth:`add_new_collection` for details about child creation.
@@ -179,7 +185,7 @@ class BaseCollection(
     def set(
         self, key: str, value: _Elem, *, use_relative_uri: Optional[bool] = None
     ) -> None:
-        """Sets an entry of this collection.
+        """Sets an entry of this collection. [lifecycle: experimental]
 
         Important note: Because parent objects may need to share
         implementation-internal state with children, when you set an item in a
@@ -206,7 +212,9 @@ class BaseCollection(
 
 
 class Collection(BaseCollection[_Elem]):
-    """SOMA Collection imposing no semantics on the contained values."""
+    """SOMA Collection imposing no semantics on the contained values.
+    [lifecycle: experimental]
+    """
 
     soma_type: Final = "SOMACollection"  # type: ignore[misc]
     __slots__ = ()

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -35,9 +35,9 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
-        """Creates a new Collection at the given URI and returns it.
+        """Creates a new collection of this type at the given URI.
 
-        The collection will be returned in the opened state.
+        The collection will be returned opened for writing.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -404,7 +404,7 @@ class ReadIter(Iterator[_T], metaclass=abc.ABCMeta):
         """Returns all the requested data in a single operation.
 
         If some data has already been retrieved using ``next``, this will return
-        the rest of the data after that is already returned.
+        the rest of the data after that which has already been returned.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -65,7 +65,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        coords: Optional[options.SparseDFCoords] = (),
+        coords: options.SparseDFCoords = (),
         column_names: Optional[Sequence[str]] = None,
         *,
         batch_size: options.BatchSize = options.BatchSize(),
@@ -84,7 +84,9 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             a partitioned read, and which part of the data to include.
         :param result_order: the order to return results, specified as a
             :class:`~options.ResultOrder` or its string value.
-        :param value_filter: an optional [value filter] to apply to the results.
+        :param value_filter: an optional value filter to apply to the results.
+            Value filter syntax is implementation-defined; see the documentation
+            for a particular SOMA implementation for examples.
             Defaults to no filter.
 
         **Indexing:**
@@ -98,7 +100,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         - If the sequence is shorter than the number of indexed coordinates,
           then no constraint (i.e. ``None``) is used for the remaining
           indexed dimensions.
-        - Specifying ``None`` or an empty sequence (e.g. ``()``) represents
+        - Specifying an empty sequence (e.g. ``()``, the default) represents
           no constraints over any dimension, returning the entire dataset.
 
         Each dimension may be indexed as follows:
@@ -213,7 +215,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        coords: options.DenseNDCoords,
+        coords: options.DenseNDCoords = (),
         *,
         partitions: Optional[options.ReadPartitions] = None,
         result_order: options.ResultOrderStr = _RO_AUTO,
@@ -239,10 +241,12 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
         Indexing is performed on a per-dimension basis.
 
         - A sequence of coordinates is accepted, one per dimension.
-        - The sequence length must be less than the number of dimensions.
+        - The sequence length must be less than or equal to
+          the number of dimensions.
         - If the sequence is shorter than the number of dimensions, the
-          remaining dimensions are unconstrained. (Thus, if an empty sequence
-          is provided, the entire array will be returned.)
+          remaining dimensions are unconstrained.
+        - Specifying an empty sequence (e.g. ``()``, the default) represents
+          no constraints over any dimension, returning the entire dataset.
 
         Each dimension may be indexed by value or slice:
 
@@ -294,7 +298,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read(
         self,
-        coords: Optional[options.SparseNDCoords] = (),
+        coords: options.SparseNDCoords = (),
         *,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,
@@ -329,7 +333,8 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
           the number of dimensions.
         - If the sequence is shorter than the number of dimensions, the
           remaining dimensions are unconstrained.
-        - Specifying ``None`` or an empty sequence will return the entire array.
+        - Specifying an empty sequence (e.g. ``()``, the default) represents
+          no constraints over any dimension, returning the entire dataset.
 
         Each dimension may be indexed as follows:
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -85,9 +85,9 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         :param result_order: the order to return results, specified as a
             :class:`~options.ResultOrder` or its string value.
         :param value_filter: an optional value filter to apply to the results.
-            Value filter syntax is implementation-defined; see the documentation
-            for a particular SOMA implementation for examples.
-            Defaults to no filter.
+            The default of ``None`` represents no filter. Value filter syntax
+            is implementation-defined; see the documentation for a particular
+            SOMA implementation for details.
 
         **Indexing:**
 

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Iterator, NoReturn, Optional, TypeVar
 from typing_extensions import Self
 
+from .. import options
+
 from .. import base
 from .. import collection
 from .. import data
@@ -66,6 +68,14 @@ class BaseCollection(collection.BaseCollection[_Elem]):
     add_new_dataframe = add_new_collection
     add_new_sparse_ndarray = add_new_collection
     add_new_dense_ndarray = add_new_collection
+
+    @property
+    def closed(self) -> bool:
+        return False  # With no backing storage, there is nothing to close.
+
+    @property
+    def mode(self) -> options.OpenMode:
+        return "w"  # This collection is always writable.
 
     def set(
         self, key: str, value: _Elem, *, use_relative_uri: Optional[bool] = None


### PR DESCRIPTION
- Adds `mode`, `close`, and `closed` methods/properties.
- Fills in most of the docstrings with details about parameters and expected behavior.

---

This change depends upon the result of https://github.com/single-cell-data/TileDB-SOMA/pull/910.

Part of #107 and https://github.com/single-cell-data/TileDB-SOMA/issues/638.