### PR TITLE
Add new supported types and improve precision of coordinates

### DIFF
--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -7,6 +7,8 @@ SOMA types that require them, not reimplemented by the implementing package.
 import enum
 from typing import Any, Mapping, Optional, Sequence, Union
 
+from . import types
+
 import attrs
 import numpy as np
 import numpy.typing as npt
@@ -109,43 +111,39 @@ ResultOrderStr = Union[ResultOrder, Literal["auto", "row-major", "column-major"]
 """A ResultOrder, or the str representing it."""
 
 
-DenseCoord = Union[int, slice]
-"""A single coordinate range for reading dense data."""
+DenseCoord = Union[None, int, types.Slice[int]]
+"""A single coordinate range for reading dense data.
+
+``None`` indicates the entire domain of a dimension; values of this type are
+not ``Optional``, but may be ``None``.
+"""
 DenseNDCoords = Sequence[DenseCoord]
 """A sequence of ranges to read dense data."""
 
 # TODO: Add support for non-integer types.
 SparseDFCoord = Union[
-    None,
-    int,
-    slice,
+    DenseCoord,
     Sequence[int],
+    Sequence[str],
+    Sequence[bytes],
+    types.Slice[bytes],
+    types.Slice[str],
     pa.Array,
     pa.ChunkedArray,
     npt.NDArray[np.integer],
 ]
-"""A single coordinate range for reading sparse dataframes.
-
-``None`` is included here since it is a valid value; parameters of this type
-are not ``Optional``, but may be ``None``.
-"""
+"""A single coordinate range for one dimension of a sparse dataframe."""
 SparseDFCoords = Sequence[SparseDFCoord]
 """A sequence of coordinate ranges for reading dense dataframes."""
 
-SparseNDCoords = Union[
-    None,
-    Sequence[
-        Union[
-            None,
-            DenseCoord,
-            Sequence[int],
-            npt.NDArray[np.integer],
-            pa.IntegerArray,
-        ]
-    ],
+SparseNDCoord = Union[
+    DenseCoord,
+    Sequence[int],
+    npt.NDArray[np.integer],
+    pa.IntegerArray,
 ]
-"""A sequence of coordinate ranges for reading sparse ndarrays.
+"""A single coordinate range for one dimension of a sparse nd-array."""
 
-``None`` is included here since it is a valid value (for reading the entire
-ndarray); parameters of this type are not ``Optional`` but may be ``None``.
-"""
+
+SparseNDCoords = Sequence[SparseNDCoord]
+"""A sequence of coordinate ranges for reading sparse ndarrays."""

--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -1,0 +1,50 @@
+"""Type and interface declarations that are not specific to options."""
+
+from typing import Optional, TypeVar
+from typing_extensions import Protocol, Self, runtime_checkable
+
+
+class Comparable(Protocol):
+    """Objects that can be ``<``/``==``/``>``'d."""
+
+    def __lt__(self, __other: Self) -> bool:
+        ...
+
+    def __le__(self, __other: Self) -> bool:
+        ...
+
+    def __eq__(self, __other: object) -> bool:
+        ...
+
+    def __ne__(self, __other: object) -> bool:
+        ...
+
+    def __ge__(self, __other: Self) -> bool:
+        ...
+
+    def __gt__(self, __other: Self) -> bool:
+        ...
+
+
+_Cmp_co = TypeVar("_Cmp_co", bound=Comparable, covariant=True)
+
+
+@runtime_checkable
+class Slice(Protocol[_Cmp_co]):
+    """A slice which stores a certain type of object.
+
+    This protocol describes the built in ``slice`` type, with a hint to callers
+    about what type they should put *inside* the slice.
+    """
+
+    @property
+    def start(self) -> Optional[_Cmp_co]:
+        ...
+
+    @property
+    def stop(self) -> Optional[_Cmp_co]:
+        ...
+
+    @property
+    def step(self) -> Optional[_Cmp_co]:
+        ...


### PR DESCRIPTION
This removes `None` from the `SparseNDCoords` type (since we now accept `()` as the "return everything" value) and separates a singular `SparseNDCoord` type out from it.

Also introduces a generic `Slice` protocol, since there is no stdlib-based type annotation for "a slice of a given type". This is, unfortunately, still not useful at runtime, since `slice` is always going to resolve to `Slice[Any]`, but the annotation is useful for specification purposes.

---

This is a roundabout part of fixing https://github.com/single-cell-data/TileDB-SOMA/issues/933.