### PR TITLE
Remove the `Comparable` protocol.

### DIFF
--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -2,7 +2,7 @@
 
 import sys
 from typing import Any, NoReturn, Optional, Type, TypeVar, Sequence, TYPE_CHECKING
-from typing_extensions import Protocol, Self, TypeGuard
+from typing_extensions import Protocol, TypeGuard
 
 
 def is_nonstringy_sequence(it: Any) -> TypeGuard[Sequence]:
@@ -13,28 +13,6 @@ def is_nonstringy_sequence(it: Any) -> TypeGuard[Sequence]:
     sequence is not what users want.
     """
     return not isinstance(it, (str, bytes)) and isinstance(it, Sequence)
-
-
-class Comparable(Protocol):
-    """Objects that can be ``<``/``==``/``>``'d."""
-
-    def __lt__(self, __other: Self) -> bool:
-        ...
-
-    def __le__(self, __other: Self) -> bool:
-        ...
-
-    def __eq__(self, __other: object) -> bool:
-        ...
-
-    def __ne__(self, __other: object) -> bool:
-        ...
-
-    def __ge__(self, __other: Self) -> bool:
-        ...
-
-    def __gt__(self, __other: Self) -> bool:
-        ...
 
 
 _T = TypeVar("_T")


### PR DESCRIPTION
We don't use it anymore, and it is not useful for static analysis (you only need to implement a subset of the methods to support all comparisons) nor at runtime (every object implements all of the `__xx__` methods, but most return `NotImplemented`, meaning that `isinstance(anything, Comparable)` was always true even for things that were not comparable, like regular old `object()`.