### PR TITLE
Correctly specify the pip cache in the Github workflow.

### DIFF
--- a/.github/workflows/python-somacore.yaml
+++ b/.github/workflows/python-somacore.yaml
@@ -71,7 +71,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           cache: pip
-          cache-dependency-path: python-spec/requirements-py${{ matrix.python-version }}.txt
+          cache-dependency-path: python-spec/requirements-py3.10.txt
+          python-version: '3.10'
       - name: Set up environment
         run: |
           pip install --upgrade build pip wheel setuptools setuptools-scm


### PR DESCRIPTION
Every single run of the `upload-to-pypi` task, I would see:

    Post job cleanup.
    Error: Unexpected end of JSON input

and I had no idea why. But looking at the `setup-python` step:

    cache: pip
    cache-dependency-path: python-spec/requirements-py.txt
    check-latest: false
    token: ***
    update-environment: true

There is no `requirements-py.txt` file, because there is no `matrix` to get a `matrix.python-version` from, because it's not a matrixed step.