### PR TITLE
Mutable-X mods, and explicit shaping of `SparseNDArray`

### DIFF
--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -616,7 +616,7 @@ Create a new `SOMADataFrame` with user-specified URI and schema.
 The schema parameter must define all user-specified columns. The schema may optionally include `soma_joinid`, but an error will be raised if it is not of type Arrow.int64. If `soma_joinid` is not specified, it will be added to the schema. All other column names beginning with `soma_` are reserved, and if present in the schema, will generate an error. If the schema includes types unsupported by the SOMA implementation, an error will be raised.
 
 ```
-create(string uri, Arrow.Schema schema, string[] index_column_names, shape, platform_config, context) -> SOMADataFrame
+create(string uri, Arrow.Schema schema, string[] index_column_names, platform_config, context) -> SOMADataFrame
 ```
 
 Parameters:
@@ -624,7 +624,6 @@ Parameters:
 - `uri`: location at which to create the object.
 - `schema`: an Arrow Schema defining the per-column schema.
 - `index_column_names`: a list of column names to use as index columns, also known as "dimensions" (e.g., `['cell_type', 'tissue_type']`). All named columns must exist in the schema, and at least one index column name is required. Index column order is significant and may affect other operations (e.g., read result order). The `soma_joinid` column may be indexed.
-- `shape`: an optional sequence of positive int64 values specifying the shape of each index column. If provided, this must have the same length as `index_column_names`, and the index-column domains will be as specified. If omitted, the index-column domains will use the maximum possible int64 value.
 - [`platform_config`](#platform-specific-configuration): optional storage-engine-specific configuration.
 - [`context`](#long-lived-context-data): optional context to use for this new object.
 

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -616,7 +616,7 @@ Create a new `SOMADataFrame` with user-specified URI and schema.
 The schema parameter must define all user-specified columns. The schema may optionally include `soma_joinid`, but an error will be raised if it is not of type Arrow.int64. If `soma_joinid` is not specified, it will be added to the schema. All other column names beginning with `soma_` are reserved, and if present in the schema, will generate an error. If the schema includes types unsupported by the SOMA implementation, an error will be raised.
 
 ```
-create(string uri, Arrow.Schema schema, string[] index_column_names, platform_config, context) -> SOMADataFrame
+create(string uri, Arrow.Schema schema, string[] index_column_names, shape, platform_config, context) -> SOMADataFrame
 ```
 
 Parameters:
@@ -624,6 +624,7 @@ Parameters:
 - `uri`: location at which to create the object.
 - `schema`: an Arrow Schema defining the per-column schema.
 - `index_column_names`: a list of column names to use as index columns, also known as "dimensions" (e.g., `['cell_type', 'tissue_type']`). All named columns must exist in the schema, and at least one index column name is required. Index column order is significant and may affect other operations (e.g., read result order). The `soma_joinid` column may be indexed.
+- `shape`: an optional sequence of positive int64 values specifying the shape of each index column. If provided, this must have the same length as `index_column_names`, and the index-column domains will be as specified. If omitted, the index-column domains will use the maximum possible int64 value.
 - [`platform_config`](#platform-specific-configuration): optional storage-engine-specific configuration.
 - [`context`](#long-lived-context-data): optional context to use for this new object.
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -467,6 +467,9 @@ class SparseRead:
 
     __slots__ = ()
 
+    def coos(self) -> ReadIter[pa.SparseCOOTensor]:
+        raise NotImplementedError()
+
     def dense_tensors(self) -> ReadIter[pa.Tensor]:
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -69,7 +69,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             index column name is required.
         :param shape: The maximum capacity (domain) of the dataframe, including room
             for any intended future appends. This must be in the postive int64
-            range, or `None`.  If `None` then the maximum possible int64 will be
+            range, or ``None``.  If ``None`` then the maximum possible int64 will be
             used.  This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
@@ -202,7 +202,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
             If the type is unsupported, an error will be raised.
         :param shape: The maximum capacity of each dimension, including room
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-            All lengths must be in the postive int64 range, or `None`.
+            All lengths must be in the postive int64 range, or ``None``.
 
             For `SOMASparseNDArray` only, if a slot is None, then the maximum
             possible int64 will be used.  This makes a `SOMASparseNDArray`

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -67,10 +67,10 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             index columns (e.g., ``['cell_type', 'tissue_type']``).
             All named columns must exist in the schema, and at least one
             index column name is required.
-        :param shape: The maximum capacity of the dataframe, including room
-            for any intended future appends. This must be in the postive
-            int64 range, or `None`.  If `None` then the maximum possible
-            int64 will be used.  This makes a `SOMADataFrame` growable.
+        :param shape: The maximum capacity (domain) of the dataframe, including room
+            for any intended future appends. This must be in the postive int64
+            range, or `None`.  If `None` then the maximum possible int64 will be
+            used.  This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
 
@@ -202,10 +202,14 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
             If the type is unsupported, an error will be raised.
         :param shape: The maximum capacity of each dimension, including room
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-            All lengths must be in the postive int64 range, or `None`.  If a
-            slot is `None` -- only supported for `SparseNDArray`, not
-            `DenseNDArray` -- then the maximum possible int64 will be used.
-            This makes a `SOMASparseNDArray` growable.
+            All lengths must be in the postive int64 range, or `None`.
+
+            For `SOMASparseNDArray` only, if a slot is None then the maximum
+            possible int64 will be used.  This makes a `SOMASparseNDArray`
+            growable.  It's necessary to say `shape=(None, None)` or
+            `shape=(None, None, None)` rather than more simply `shape=None`
+            since the first two are how one specifies N=2 or N=3, respectively,
+            for N-dimensional arrays.
         """
         raise NotImplementedError()
 
@@ -214,7 +218,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def shape(self) -> Tuple[int, ...]:
-        """The capacity of each dimension of this array.
+        """The maximum capacity (domain) of each dimension of this array.
         [lifecycle: experimental]
         """
         raise NotImplementedError()

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -206,10 +206,12 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
 
             For `SOMASparseNDArray` only, if a slot is None, then the maximum
             possible int64 will be used.  This makes a `SOMASparseNDArray`
-            growable.  It's necessary to say `shape=(None, None)` or
-            `shape=(None, None, None)` rather than more simply `shape=None`
-            since the first two are how one specifies N=2 or N=3, respectively,
-            for N-dimensional arrays.
+            growable.
+
+            It's necessary to say `shape=(None, None)` or `shape=(None, None, None)`
+            rather than more simply `shape=None` since the first two are how one
+            specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
+            of this sequence is the number of dimensions of the array.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -204,7 +204,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
             All lengths must be in the postive int64 range, or `None`.
 
-            For `SOMASparseNDArray` only, if a slot is None then the maximum
+            For `SOMASparseNDArray` only, if a slot is None, then the maximum
             possible int64 will be used.  This makes a `SOMASparseNDArray`
             growable.  It's necessary to say `shape=(None, None)` or
             `shape=(None, None, None)` rather than more simply `shape=None`

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -197,11 +197,10 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
             If the type is unsupported, an error will be raised.
         :param shape: The maximum capacity of each dimension, including room
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-            All lengths must be in the postive int64 range, or ``None``.
-            It's necessary to say ``shape=(None, None)`` or ``shape=(None, None, None)``
-            rather than more simply ``shape=None`` since the first two are how one
-            specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
-            of this sequence is the number of dimensions of the array.
+            All lengths must be in the postive int64 range, or ``None``.  It's
+            necessary to say ``shape=(None, None)`` or ``shape=(None, None,
+            None)``, as the sequence length determines the number of dimensions
+            N in the N-dimensional array.
 
             For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
             possible int64 will be used.  This makes a ``SOMASparseNDArray``

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -45,7 +45,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
-        shape: Optional[int] = None,
+        shape: Optional[Sequence[int]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -67,10 +67,12 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             index columns (e.g., ``['cell_type', 'tissue_type']``).
             All named columns must exist in the schema, and at least one
             index column name is required.
-        :param shape: The maximum capacity (domain) of the dataframe, including room
-            for any intended future appends. This must be in the postive int64
-            range, or ``None``.  If ``None`` then the maximum possible int64 will be
-            used.  This makes a `SOMADataFrame` growable.
+        :param shape: An optional sequence of positive int64 values specifying the
+            shape of each index column, including room for any intended future
+            appends. If provided, this must have the same length as
+            `index_column_names`, and the index-column domains will be as specified.
+            If omitted, the index-column domains will use the maximum possible int64
+            value.  This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -190,7 +190,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         uri: str,
         *,
         type: pa.DataType,
-        shape: Sequence[Union[int, None]],
+        shape: Sequence[Optional[int]],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -199,12 +199,12 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
             All lengths must be in the postive int64 range, or ``None``.
 
-            For `SOMASparseNDArray` only, if a slot is None, then the maximum
-            possible int64 will be used.  This makes a `SOMASparseNDArray`
+            For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
+            possible int64 will be used.  This makes a ``SOMASparseNDArray``
             growable.
 
-            It's necessary to say `shape=(None, None)` or `shape=(None, None, None)`
-            rather than more simply `shape=None` since the first two are how one
+            It's necessary to say ``shape=(None, None)`` or ``shape=(None, None, None)``
+            rather than more simply ``shape=None`` since the first two are how one
             specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
             of this sequence is the number of dimensions of the array.
         """

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -198,15 +198,14 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         :param shape: The maximum capacity of each dimension, including room
             for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
             All lengths must be in the postive int64 range, or ``None``.
-
-            For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
-            possible int64 will be used.  This makes a ``SOMASparseNDArray``
-            growable.
-
             It's necessary to say ``shape=(None, None)`` or ``shape=(None, None, None)``
             rather than more simply ``shape=None`` since the first two are how one
             specifies N=2 or N=3, respectively, for N-dimensional arrays: the length
             of this sequence is the number of dimensions of the array.
+
+            For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
+            possible int64 will be used.  This makes a ``SOMASparseNDArray``
+            growable.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -45,7 +45,6 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
-        shape: Optional[Sequence[int]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -67,12 +66,6 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             index columns (e.g., ``['cell_type', 'tissue_type']``).
             All named columns must exist in the schema, and at least one
             index column name is required.
-        :param shape: An optional sequence of positive int64 values specifying the
-            shape of each index column, including room for any intended future
-            appends. If provided, this must have the same length as
-            `index_column_names`, and the index-column domains will be as specified.
-            If omitted, the index-column domains will use the maximum possible int64
-            value.  This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -45,6 +45,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
+        shape: Optional[int] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -66,6 +67,10 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             index columns (e.g., ``['cell_type', 'tissue_type']``).
             All named columns must exist in the schema, and at least one
             index column name is required.
+        :param shape: The maximum capacity of the dataframe, including room
+            for any intended future appends. This must be in the postive
+            int64 range, or `None`.  If `None` then the maximum possible
+            int64 will be used.  This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
 
@@ -185,7 +190,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         uri: str,
         *,
         type: pa.DataType,
-        shape: Sequence[int],
+        shape: Sequence[Union[int, None]],
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -195,8 +200,12 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         :param uri: The URI where the array will be created.
         :param type: The Arrow type to store in the array.
             If the type is unsupported, an error will be raised.
-        :param shape: The length of each dimension as a sequence,
-            e.g. ``(100, 10)``. All lengths must be in the postive int64 range.
+        :param shape: The maximum capacity of each dimension, including room
+            for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
+            All lengths must be in the postive int64 range, or `None`.  If a
+            slot is `None` -- only supported for `SparseNDArray`, not
+            `DenseNDArray` -- then the maximum possible int64 will be used.
+            This makes a `SOMASparseNDArray` growable.
         """
         raise NotImplementedError()
 
@@ -205,7 +214,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def shape(self) -> Tuple[int, ...]:
-        """The length of each dimension of this array.
+        """The capacity of each dimension of this array.
         [lifecycle: experimental]
         """
         raise NotImplementedError()
@@ -339,8 +348,6 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
 
             some_dense_array.read(...).tables()
             # -> an iterator of Arrow Tables
-            some_dense_array.read(...).csrs().all()
-            # -> a single flattened sparse CSR matrix
 
         :param coords: A per-dimension sequence of coordinates defining
             the range to be read.
@@ -453,15 +460,6 @@ class SparseRead:
     """
 
     __slots__ = ()
-
-    def coos(self) -> ReadIter[pa.SparseCOOTensor]:
-        raise NotImplementedError()
-
-    def cscs(self) -> ReadIter[pa.SparseCSCMatrix]:
-        raise NotImplementedError()
-
-    def csrs(self) -> ReadIter[pa.SparseCSRMatrix]:
-        raise NotImplementedError()
 
     def dense_tensors(self) -> ReadIter[pa.Tensor]:
         raise NotImplementedError()

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -120,7 +120,8 @@ not ``Optional``, but may be ``None``.
 DenseNDCoords = Sequence[DenseCoord]
 """A sequence of ranges to read dense data."""
 
-# TODO: Add support for non-integer types.
+# TODO: Add support for types other than int/string
+# https://github.com/single-cell-data/TileDB-SOMA/issues/960
 SparseDFCoord = Union[
     DenseCoord,
     Sequence[int],


### PR DESCRIPTION
Implements the spec side of the plan laid out in issue https://github.com/single-cell-data/TileDB-SOMA/issues/931.

This PR addresses only explicit shaping of `SparseNDArray` -- explicit shaping of `DataFrame` will be on a separate PR.