### PR TITLE
[python] Re-enable isort via ruff; fix `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,5 @@
 global-exclude *
 include pyproject.toml
 include MANIFEST.in
-recursive-include python-spec/README.md
+recursive python-spec/README.md
 recursive-include python-spec/src *.py py.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,5 @@
 global-exclude *
 include pyproject.toml
 include MANIFEST.in
-recursive python-spec/README.md
+include python-spec/README.md
 recursive-include python-spec/src *.py py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ write_to = "python-spec/src/somacore/_version.py"
 # by requiring `python-` at the start of the tag (e.g. `python-v1.2.3`).
 tag_regex = '^python-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 
+[tool.ruff]
+extend-select = ["I"]
+
 [tool.ruff.isort]
 force-single-line = true
 known-first-party = ["somacore"]

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, Iterator, NoReturn, Optional, TypeVar
-from typing_extensions import Self
 
-from .. import options
+from typing_extensions import Self
 
 from .. import base
 from .. import collection
 from .. import data
 from .. import experiment
 from .. import measurement
+from .. import options
 
 _Elem = TypeVar("_Elem", bound=base.SOMAObject)
 

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -7,13 +7,13 @@ SOMA types that require them, not reimplemented by the implementing package.
 import enum
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from . import types
-
 import attrs
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from typing_extensions import Final, Literal
+
+from . import types
 
 SOMA_JOINID: Final = "soma_joinid"
 """Global constant for the SOMA join ID."""

--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -1,7 +1,8 @@
 """Type and interface declarations that are not specific to options."""
 
 import sys
-from typing import Any, NoReturn, Optional, Type, TypeVar, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, Sequence, Type, TypeVar
+
 from typing_extensions import Protocol, TypeGuard
 
 

--- a/python-spec/testing/test_types.py
+++ b/python-spec/testing/test_types.py
@@ -1,6 +1,6 @@
 import itertools
-from typing import Any, Iterable
 import unittest
+from typing import Any, Iterable
 
 from somacore import types
 


### PR DESCRIPTION
In order to actually have ruff do your isorting, you have to enable the `I` error codes. This does that. Also fixes a line in the MANIFEST file.