### PR TITLE
[python] Add support for floats in axis query

### DIFF
--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -127,10 +127,12 @@ DenseNDCoords = Sequence[DenseCoord]
 SparseDFCoord = Union[
     DenseCoord,
     Sequence[int],
+    Sequence[float],
     Sequence[str],
     Sequence[bytes],
-    types.Slice[bytes],
+    types.Slice[float],
     types.Slice[str],
+    types.Slice[bytes],
     pa.Array,
     pa.ChunkedArray,
     npt.NDArray[np.integer],

--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -33,7 +33,7 @@ def _canonicalize_coord(coord: options.SparseDFCoord) -> options.SparseDFCoord:
     # NOTE: Keep this in sync with the `SparseDFCoord` type.
     if coord is None or isinstance(
         coord,
-        (bytes, int, slice, str, pa.Array, pa.ChunkedArray, np.ndarray),
+        (bytes, float, int, slice, str, pa.Array, pa.ChunkedArray, np.ndarray),
     ):
         return coord
     if isinstance(coord, Sequence):

--- a/python-spec/testing/test_query_axis.py
+++ b/python-spec/testing/test_query_axis.py
@@ -14,7 +14,9 @@ from somacore import options
         ((), ()),
         ((slice(1, 10),), (slice(1, 10),)),
         ([0, 1, 2], (0, 1, 2)),
+        ([1, 1.5, 2], (1, 1.5, 2)),
         ((slice(None), [0, 88, 1001]), (slice(None), (0, 88, 1001))),
+        ((slice(2.5, 3.5),), (slice(2.5, 3.5),)),
         (("string-coord", [b"lo", b"hi"]), ("string-coord", (b"lo", b"hi"))),
     ],
 )
@@ -36,7 +38,6 @@ def test_canonicalization_nparray() -> None:
     [
         ("forbid bare strings",),
         (b"forbid bare byteses",),
-        ([1, 1.5, 2],),
         (999,),
     ],
 )


### PR DESCRIPTION
As of recently [1], TileDB-SOMA now supports floats when indexing dataframes.  We should no longer forbid them in axis queries.

[1]: https://github.com/single-cell-data/TileDB-SOMA/pull/968

Context: issue https://github.com/single-cell-data/TileDB-SOMA/issues/960