### PR TITLE
[python] Add `bool` to supported types and improve type specification

### DIFF
--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -34,6 +34,7 @@ def _canonicalize_coord(coord: options.SparseDFCoord) -> options.SparseDFCoord:
     if coord is None or isinstance(
         coord,
         (
+            bool,
             bytes,
             float,
             int,

--- a/python-spec/testing/test_query_axis.py
+++ b/python-spec/testing/test_query_axis.py
@@ -22,6 +22,7 @@ from somacore import options
             (slice(np.datetime64(946684802, "s"), np.datetime64(946684803, "s")),),
         ),
         (("string-coord", [b"lo", b"hi"]), ("string-coord", (b"lo", b"hi"))),
+        ((slice(4, 5), True, None), (slice(4, 5), True, None)),
     ],
 )
 def test_canonicalization(coords: Any, want: Tuple[options.SparseDFCoord, ...]) -> None:


### PR DESCRIPTION
This adds boolean to the supported sparse coordinate types and also improves the type definition of coordinate types to ensure that the values in each type are homogeneous:

    BadCoord = Union[int, str]
    BadCoords = Union[BadCoord, Sequence[BadCoord]]
    # ["this", 1] is bad, but is a valid as a BadCoords value

    GoodCoord = TypeVar("GoodCoord", int, str)
    GoodCoords = Union[GoodCoord, Sequence[GoodCoord]]
    # ["this", 1] is bad, and is *not* valid as a GoodCoords value
    # ["this", "that"] is a valid as a GoodCoords value
    # [1, 2] is valid as a GoodCoords value

---

I don’t see a bug entry for this but it was something we discussed earlier today, and in the process I realized another thing we could improve.

Context: #960