### PR TITLE
[python] Explicit shaping for `DataFrame`

### DIFF
--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -70,13 +70,17 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             All named columns must exist in the schema, and at least one
             index column name is required.
 
-        :param domains: An optional sequence of min-max tuples specifying the
-            domain of each index column, including room for any intended future
-            appends.  If provided, this sequence must have the same length as
-            `index_column_names`, and the index-column domains will be as specified.
-            If omitted entirely, or if ``None`` in a given dimension, the
-            corresponding index-column domain will use the maximum possible values.
-            This makes a `SOMADataFrame` growable.
+        :param domains: An optional sequence of tuples specifying the domain of each
+            index column. Each tuple should be a pair consisting of the minimum and
+            maximum values storable in the index column. For example, if there is a
+            single int64-valued index column, then ``domains`` might be ``[(100,
+            200)]`` to indicate that values between 100 and 200, inclusive, can be
+            stored in that column.  If provided, this sequence must have the same
+            length as `index_column_names`, and the index-column domains will be as
+            specified.  If omitted entirely, or if ``None`` in a given dimension,
+            the corresponding index-column domain will use the minimum and maximum
+            possible values for the column's datatype.  This makes a
+            ``SOMADataFrame`` growable.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -45,6 +45,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
+        domains: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -58,14 +59,24 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         is provided, one will be added.  It may be used as an indexed column.
 
         :param uri: The URI where the ``DataFrame`` will be created.
+
         :param schema: Arrow schema defining the per-column schema. This schema
             must define all columns, including columns to be named as index
             columns.  If the schema includes types unsupported by the SOMA
             implementation, an error will be raised.
+
         :param index_column_names: A list of column names to use as user-defined
             index columns (e.g., ``['cell_type', 'tissue_type']``).
             All named columns must exist in the schema, and at least one
             index column name is required.
+
+        :param domains: An optional sequence of min-max tuples specifying the
+            domain of each index column, including room for any intended future
+            appends.  If provided, this sequence must have the same length as
+            `index_column_names`, and the index-column domains will be as specified.
+            If omitted entirely, or if ``None`` in a given dimension, the
+            corresponding index-column domain will use the maximum possible values.
+            This makes a `SOMADataFrame` growable.
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -186,6 +186,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @property
+    @abc.abstractmethod
     def domain(self) -> Tuple[Tuple[Any, Any], ...]:
         """
         Returns a tuple of minimum and maximum values, inclusive, storable

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -45,7 +45,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
-        domains: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -70,13 +70,13 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             All named columns must exist in the schema, and at least one
             index column name is required.
 
-        :param domains: An optional sequence of tuples specifying the domain of each
+        :param domain: An optional sequence of tuples specifying the domain of each
             index column. Each tuple should be a pair consisting of the minimum and
             maximum values storable in the index column. For example, if there is a
-            single int64-valued index column, then ``domains`` might be ``[(100,
+            single int64-valued index column, then ``domain`` might be ``[(100,
             200)]`` to indicate that values between 100 and 200, inclusive, can be
             stored in that column.  If provided, this sequence must have the same
-            length as `index_column_names`, and the index-column domains will be as
+            length as `index_column_names`, and the index-column domain will be as
             specified.  If omitted entirely, or if ``None`` in a given dimension,
             the corresponding index-column domain will use the minimum and maximum
             possible values for the column's datatype.  This makes a
@@ -182,6 +182,14 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     def index_column_names(self) -> Tuple[str, ...]:
         """The names of the index (dimension) columns.
         [lifecycle: experimental]
+        """
+        raise NotImplementedError()
+
+    @property
+    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """
+        Returns a tuple of minimum and maximum values, inclusive, storable
+        on each index column of the dataframe.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SOMA/issues/961

This is a prerequisite for https://github.com/single-cell-data/TileDB-SOMA/pull/1027.

Note that for `SparseNDArray` it sufficed to have a slotwise int `shape`: indexing is only by `int64` and we took the min to be 0, leaving only the max to be specified. Here, for `DataFrame`, indices can be of various types so we truly must do parameterizations in terms of domains -- min-max pairs on each dim slot.