### PR TITLE
[python] Convert docstrings to Google style

### DIFF
--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -131,6 +131,8 @@ class SOMAObject(metaclass=abc.ABCMeta):
         This is also called automatically by the Python interpreter via
         ``__del__`` when this object is garbage collected, so the implementation
         must be idempotent.
+
+        Lifecycle: experimental
         """
         # Default implementation does nothing.
 

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -28,13 +28,15 @@ class SOMAObject(metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
         """Opens the SOMA object of this type at the given URI.
-        [lifecycle: experimental]
 
-        :param uri: The URI of the object to open.
-        :param mode: The mode to open this in, either `r` or `w`.
-        :param context: The Context value to use when opening the object.
-        :param platform_config: Platform configuration options specific to
-            this open operation.
+        Args:
+            uri: The URI of the object to open.
+            mode: The mode to open this in, either `r` or `w`.
+            context: The Context value to use when opening the object.
+            platform_config: Platform configuration options specific to
+                this open operation.
+        Returns: The SOMA object, opened for reading.
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -43,23 +45,28 @@ class SOMAObject(metaclass=abc.ABCMeta):
     def exists(cls, uri: str, *, context: Optional[Any] = None) -> bool:
         """Checks whether a SOMA object of this type is stored at the URI.
 
-        :param uri: The URI to check.
-        :param context: The Context value to use when checking existence.
-        :return: True if the object exists and is of the correct type.
+        Args:
+            uri: The URI to check.
+            context: The Context value to use when checking existence.
+        Returns:
+            True if the object exists and is of the correct type.
             False if the object does not exist, or is of a different type.
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def uri(self) -> str:
-        """Returns the URI of this SOMA object. [lifecycle: experimental]"""
+        """The URI of this SOMA object.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()
 
     @property
     def context(self) -> Any:
         """A value storing implementation-specific configuration information.
-        [lifecycle: experimental]
 
         This contains long-lived (i.e., not call-specific) information that is
         used by the SOMA implementation to access storage. This may include
@@ -68,17 +75,21 @@ class SOMAObject(metaclass=abc.ABCMeta):
         End users should treat this as an opaque value. While it may be passed
         from an existing SOMA object to be used in the creation of a new SOMA
         object, it should not be inspected.
+
+        Lifecycle: experimental
         """
         return None
 
     @property
     @abc.abstractmethod
     def metadata(self) -> MutableMapping[str, Any]:
-        """The metadata of this SOMA object. [lifecycle: experimental]
+        """The metadata of this SOMA object.
 
         The returned value directly references the stored metadata; reads from
         and writes to it (provided the object is opened) are reflected in
         storage.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -86,15 +97,17 @@ class SOMAObject(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def mode(self) -> options.OpenMode:
         """Returns the mode this object was opened in, either ``r`` or ``w``.
-        [lifecycle: experimental]
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def closed(self) -> bool:
-        """Returns True if this object has been closed; False if still open.
-        [lifecycle: experimental]
+        """True if this object has been closed; False if still open.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -111,9 +124,13 @@ class SOMAObject(metaclass=abc.ABCMeta):
 
     def close(self) -> None:
         """Releases any external resources held by this object.
-        [lifecycle: experimental]
 
-        An implementation of close must be idempotent.
+        For objects opened for write, this also finalizes the write operation
+        and ensures that all writes are completed before returning.
+
+        This is also called automatically by the Python interpreter via
+        ``__del__`` when this object is garbage collected, so the implementation
+        must be idempotent.
         """
         # Default implementation does nothing.
 

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -119,8 +119,8 @@ class BaseCollection(
 
         The way the URI is constructed is left unspecified so that an
         implementation can create a URI based on its own needs. Users should
-        directly get the URI of the new child if they need it; they should never
-        assume what it will be.
+        directly get the URI of the new child using ``new_child.uri`` if needed;
+        they should never assume what it will be.
 
         Args:
             key: The key that this child should live at

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -17,12 +17,13 @@ _CT = TypeVar("_CT", bound="BaseCollection")
 class BaseCollection(
     base.SOMAObject, MutableMapping[str, _Elem], metaclass=abc.ABCMeta
 ):
-    """A generic string-keyed collection of :class:`SOMAObject`s.
-    [lifecycle: experimental]
+    """A generic string-keyed collection of :class:`base.SOMAObject`s.
 
     The generic type specifies what type the Collection may contain. At its
     most generic, a Collection may contain any SOMA object, but a subclass
     may specify that it is a Collection of a specific type of SOMA object.
+
+    Lifecycle: experimental
     """
 
     __slots__ = ()
@@ -37,9 +38,12 @@ class BaseCollection(
         context: Optional[Any] = None,
     ) -> Self:
         """Creates a new collection of this type at the given URI.
-        [lifecycle: experimental]
 
-        The collection will be returned opened for writing.
+        Args:
+            uri: The URI where the collection will be created.
+        Returns:
+            The newly created collection, opened for writing.
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -83,43 +87,55 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "BaseCollection":
         """Creates a new sub-collection of this collection.
-        [lifecycle: experimental]
-
         To add an existing collection as a sub-element of this collection,
-        use :meth:`set` or indexed access instead.
+        use :meth:`set` or indexed access (``coll[name] = value``) instead.
 
         The type provided is used to create the skeleton of this collection
         as in :meth:`create`. By default, this will create a basic collection::
 
             # Create a child Measurement object at the key "density"
             # with default settings.
-            #
-            # This creates both the backing Measurement collection, as well as
-            # the necessary sub-elements to have a complete Measurement.
             density = the_collection.add_new_collection("density", somacore.Measurement)
 
-            # This will create a basic Collection as a child.
-            sub_child = density.add_new_collection("sub_child")
+            # This will create a basic Collection as a child at the location
+            # storage://authority/path/to/sub-child.
+            sub_child = density.add_new_collection(
+                "sub_child", uri="storage://authority/path/to/sub-child")
 
-        In situations where relative URIs are supported, the default URI of the
-        child should be a sub-path of the parent URI. The final component
-        should be a path-sanitized version of the new key. For instance, adding
-        sub-element ``data`` to a Collection located at ``file:///path/to/coll``
-        would have a default path of ``file:///path/to/coll/data``. For
-        non–URI-safe keys, no specific path-sanitization method is required,
-        but as an example, a child named ``non/path?safe`` could use
-        ``file:///path/to/coll/non_path_safe`` as its full URI.
+        The URI provided may be absolute or relative. If a child URI is not
+        provided, the collection should construct a default child URI based
+        on the key of the new entry, making a relative URI (when possible)::
 
-        When a specific child URI is specified, that exact URI should be used
-        (whether relative or absolute).
+            # coll URI is "file:///path/to/coll"
+            coll.add_new_collection("new child!")
+            # The URI of the child collection might be:
+            # "file:///path/to/coll/new_child"
 
-        :param key: The key that this child should live at (i.e., it will be
-            accessed via ``the_collection[key]``).
-        :param kind: The type of child that should be added.
-        :param uri: If provided, overrides the default URI that would be used
-            to create this object. This may be absolute or relative.
-        :param platform_config: Platform-specific configuration options used
-            when creating the child.
+            # flat_ns_coll URI is "flat://authority/key" in a flat namespace
+            # where relative paths are unsupported.
+            flat_ns_coll.add_new_collection("flat child")
+            # The URI of the child collection might be:
+            # "flat://authority/flat_child"
+
+        The way the URI is constructed is left unspecified so that an
+        implementation can create a URI based on its own needs. Users should
+        directly get the URI of the new child if they need it; they should never
+        assume what it will be.
+
+        Args:
+            key: The key that this child should live at
+                (i.e., it will be accessed via ``the_collection[key]``).
+            kind: The type of child that should be added.
+            uri: If provided, overrides the default URI that would be used
+                to create this object. This may be absolute or relative.
+                If not provided,
+            platform_config: Platform-specific configuration options used
+                when creating the child.
+
+        Returns:
+            The newly created collection, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -134,10 +150,14 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.DataFrame:
         """Creates a new DataFrame as a child of this collection.
-        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.DataFrame.create`.
-        See :meth:`add_new_collection` for details about child creation.
+        See :meth:`add_new_collection` for details about child URIs.
+
+        Returns:
+            The newly created DataFrame, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -152,10 +172,14 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.DenseNDArray:
         """Creates a new dense NDArray as a child of this collection.
-        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.DenseNDArray.create`.
-        See :meth:`add_new_collection` for details about child creation.
+        See :meth:`add_new_collection` for details about child URIs.
+
+        Returns:
+            The newly created dense NDArray, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -170,10 +194,14 @@ class BaseCollection(
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.SparseNDArray:
         """Creates a new sparse NDArray as a child of this collection.
-        [lifecycle: experimental]
 
         Parameters are as in :meth:`data.SparseNDArray.create`.
         See :meth:`add_new_collection` for details about child creation.
+
+        Returns:
+            The newly created sparse NDArray, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -185,7 +213,7 @@ class BaseCollection(
     def set(
         self, key: str, value: _Elem, *, use_relative_uri: Optional[bool] = None
     ) -> Self:
-        """Sets an entry of this collection. [lifecycle: experimental]
+        """Sets an entry of this collection.
 
         Important note: Because parent objects may need to share
         implementation-internal state with children, when you set an item in a
@@ -198,23 +226,31 @@ class BaseCollection(
 
         The two objects *will* refer to the same stored data.
 
-        :param use_relative_uri: Determines whether to store the collection
-            entry with a relative URI (provided the storage engine supports it).
-            If ``None`` (the default), will automatically determine whether to
-            use an absolute or relative URI based on their relative location
-            (if supported by the storage engine).
-            If ``True``, will always use a relative URI. If the new child does
-            not share a relative URI base, or use of relative URIs is not
-            possible at all, the collection should throw an exception.
-            If ``False``, will always use an absolute URI.
-        :return: ``self``, to enable method chaining.
+        Args:
+            key: The string key to set.
+            value: The SOMA object to insert into the collection.
+            use_relative_uri: Determines whether to store the collection
+                entry with a relative URI (provided the storage engine
+                supports it).
+                If ``None`` (the default), will automatically determine whether
+                to use an absolute or relative URI based on their relative
+                location.
+                If ``True``, will always use a relative URI. If the new child
+                does not share a relative URI base, or use of relative URIs
+                is not possible at all, the collection should raise an error.
+                If ``False``, will always use an absolute URI.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
 
 class Collection(BaseCollection[_Elem]):
     """SOMA Collection imposing no semantics on the contained values.
-    [lifecycle: experimental]
+
+    Lifecycle: experimental
     """
 
     soma_type: Final = "SOMACollection"  # type: ignore[misc]

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -29,7 +29,8 @@ _RO_AUTO = options.ResultOrder.AUTO
 
 class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     """A multi-column table with a user-defined schema.
-    [lifecycle: experimental]
+
+    Lifecycle: experimental
     """
 
     __slots__ = ()
@@ -50,7 +51,6 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         context: Optional[Any] = None,
     ) -> Self:
         """Creates a new ``DataFrame`` at the given URI.
-        [lifecycle: experimental]
 
         The schema of the created dataframe will include a column named
         ``soma_joinid`` of type ``pyarrow.int64``, with negative values
@@ -58,29 +58,36 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         schema, it must be of the correct type.  If no ``soma_joinid`` column
         is provided, one will be added.  It may be used as an indexed column.
 
-        :param uri: The URI where the ``DataFrame`` will be created.
+        Args:
+            uri: The URI where the dataframe will be created.
 
-        :param schema: Arrow schema defining the per-column schema. This schema
-            must define all columns, including columns to be named as index
-            columns.  If the schema includes types unsupported by the SOMA
-            implementation, an error will be raised.
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
 
-        :param index_column_names: A list of column names to use as user-defined
-            index columns (e.g., ``['cell_type', 'tissue_type']``).
-            All named columns must exist in the schema, and at least one
-            index column name is required.
+            index_column_names: A list of column names to use as user-defined
+                index columns (e.g., ``['cell_type', 'tissue_type']``).
+                All named columns must exist in the schema, and at least one
+                index column name is required.
 
-        :param domain: An optional sequence of tuples specifying the domain of each
-            index column. Each tuple should be a pair consisting of the minimum and
-            maximum values storable in the index column. For example, if there is a
-            single int64-valued index column, then ``domain`` might be ``[(100,
-            200)]`` to indicate that values between 100 and 200, inclusive, can be
-            stored in that column.  If provided, this sequence must have the same
-            length as `index_column_names`, and the index-column domain will be as
-            specified.  If omitted entirely, or if ``None`` in a given dimension,
-            the corresponding index-column domain will use the minimum and maximum
-            possible values for the column's datatype.  This makes a
-            ``SOMADataFrame`` growable.
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Each tuple should be a pair consisting of
+                the minimum and maximum values storable in the index column.
+                For example, if there is a single int64-valued index column,
+                then ``domain`` might be ``[(100, 200)]`` to indicate that
+                values between 100 and 200, inclusive, can be stored in that
+                column.  If provided, this sequence must have the same length as
+                ``index_column_names``, and the index-column domain will be as
+                specified.  If omitted entirely, or if ``None`` in a given
+                dimension, the corresponding index-column domain will use
+                the minimum and maximum possible values for the column's
+                datatype.  This makes a dataframe growable.
+
+        Returns:
+            The newly created dataframe, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -99,20 +106,23 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "ReadIter[pa.Table]":
         """Reads a user-defined slice of data into Arrow tables.
-        [lifecycle: experimental]
 
-        :param coords: for each index dimension, which rows to read.
-            Defaults to ``()``, meaning no constraint -- all IDs.
-        :param column_names: the named columns to read and return.
-            Defaults to ``None``, meaning no constraint -- all column names.
-        :param partitions: If present, specifies that this is part of
-            a partitioned read, and which part of the data to include.
-        :param result_order: the order to return results, specified as a
-            :class:`~options.ResultOrder` or its string value.
-        :param value_filter: an optional value filter to apply to the results.
-            The default of ``None`` represents no filter. Value filter syntax
-            is implementation-defined; see the documentation for a particular
-            SOMA implementation for details.
+        Args:
+            coords: for each index dimension, which rows to read.
+                Defaults to ``()``, meaning no constraint -- all IDs.
+            column_names: the named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            partitions: If present, specifies that this is part of
+                a partitioned read, and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+        Returns:
+            A :class:`ReadIter` of :class:`pa.Table`s.
+
 
         **Indexing:**
 
@@ -144,6 +154,8 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
           and not as indices relative to the end, unlike traditional Python
           sequence indexing. For instance, ``slice(-10, 3)`` indicates the range
           from −10 to 3 on the given dimension.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -155,15 +167,18 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
         """Writes the data from an Arrow table to the persistent object.
-        [lifecycle: experimental]
 
         As duplicate index values are not allowed, index values already present
         in the object are overwritten and new index values are added.
 
-        :param values: An Arrow table containing all columns, including
-            the index columns. The schema for the values must match
-            the schema for the ``DataFrame``.
-        :return: ``self``, to enable method chaining.
+        Args:
+            values: An Arrow table containing all columns, including
+                the index columns. The schema for the values must match
+                the schema for the ``DataFrame``.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -173,7 +188,8 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def schema(self) -> pa.Schema:
         """The schema of the data in this dataframe.
-        [lifecycle: experimental]
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -181,16 +197,20 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def index_column_names(self) -> Tuple[str, ...]:
         """The names of the index (dimension) columns.
-        [lifecycle: experimental]
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def domain(self) -> Tuple[Tuple[Any, Any], ...]:
-        """
-        Returns a tuple of minimum and maximum values, inclusive, storable
-        on each index column of the dataframe.
+        """The allowable range of values in each index column.
+
+        Returns: a tuple of minimum and maximum values, inclusive,
+            storable on each index column of the dataframe.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -214,21 +234,25 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
         context: Optional[Any] = None,
     ) -> Self:
         """Creates a new ND array of the current type at the given URI.
-        [lifecycle: experimental]
 
-        :param uri: The URI where the array will be created.
-        :param type: The Arrow type to store in the array.
-            If the type is unsupported, an error will be raised.
-        :param shape: The maximum capacity of each dimension, including room
-            for any intended future appends, as a sequence.  E.g. ``(100, 10)``.
-            All lengths must be in the postive int64 range, or ``None``.  It's
-            necessary to say ``shape=(None, None)`` or ``shape=(None, None,
-            None)``, as the sequence length determines the number of dimensions
-            N in the N-dimensional array.
+        Args:
+            uri: The URI where the array will be created.
+            type: The Arrow type to store in the array.
+                If the type is unsupported, an error will be raised.
+            shape: The maximum capacity of each dimension, including room
+                for any intended future appends, specified as one element
+                per dimension, e.g. ``(100, 10)``.  All lengths must be in
+                the postive int64 range, or ``None``.  It's necessary to say
+                ``shape=(None, None)`` or ``shape=(None, None, None)``,
+                as the sequence length determines the number of dimensions
+                (N) in the N-dimensional array.
 
-            For ``SOMASparseNDArray`` only, if a slot is None, then the maximum
-            possible int64 will be used.  This makes a ``SOMASparseNDArray``
-            growable.
+                For sparse arrays only, if a slot is None, then the maximum
+                possible int64 will be used, making a sparse array growable.
+
+        Returns: The newly created array, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -238,24 +262,32 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def shape(self) -> Tuple[int, ...]:
         """The maximum capacity (domain) of each dimension of this array.
-        [lifecycle: experimental]
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
     @property
     def ndim(self) -> int:
-        """The number of dimensions in this array. [lifecycle: experimental]"""
+        """The number of dimensions in this array.
+
+        Lifecycle: experimental
+        """
         return len(self.shape)
 
     @property
     @abc.abstractmethod
     def schema(self) -> pa.Schema:
-        """The schema of the data in this array. [lifecycle: experimental]"""
+        """The schema of the data in this array.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()
 
     is_sparse: ClassVar[Literal[True, False]]
-    """True if the array is sparse. False if it is dense.
-    [lifecycle: experimental]
+    """True if the array is sparse, False if it is dense.
+
+    Lifecycle: experimental
     """
 
 
@@ -275,7 +307,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
         result_order: options.ResultOrderStr = _RO_AUTO,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> pa.Tensor:
-        """Reads the specified subarray as a Tensor. [lifecycle: experimental]
+        """Reads the specified subarray as a Tensor.
 
         Coordinates must specify a contiguous subarray, and the number of
         coordinates must be less than or equal to the number of dimensions.
@@ -283,12 +315,15 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
         include ``()``, ``(3, 4)``, ``[slice(5, 10)]``, and
         ``[slice(5, 10), slice(6, 12)]``.
 
-        :param coords: A per-dimension sequence of coordinates defining
-            the range to read.
-        :param partitions: If present, specifies that this is part of
-            a partitioned read, and which part of the data to include.
-        :param result_order: the order to return results, specified as a
-            :class:`~options.ResultOrder` or its string value.
+        Args:
+            coords: A per-dimension sequence of coordinates defining
+                the range to read.
+            partitions: If present, specifies that this is part of
+                a partitioned read, and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+
+        Returns: The data over the requested range as a tensor.
 
         **Indexing:**
 
@@ -311,6 +346,8 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
           all indices up to and including the value, and all indices
           starting from and including the value.
         - Negative indexing is not supported.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -323,17 +360,18 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
         """Writes an Arrow tensor to a subarray of the persistent object.
-        [lifecycle: experimental]
 
         The subarray written is defined by ``coords`` and ``values``. This will
         overwrite existing values in the array.
 
-        :param coords: A per-dimension tuple of scalars or slices
-            defining the bounds of the subarray to be written.
-            See :meth:`read` for details about indexing.
-        :param values: The values to be written to the subarray.  Must have
-            the same shape as ``coords``, and matching type to the array.
-        :return: ``self``, to enable method chaining.
+        Args:
+            coords: A per-dimension tuple of scalars or slices
+                defining the bounds of the subarray to be written.
+                See :meth:`read` for details about indexing.
+            values: The values to be written to the subarray.  Must have
+                the same shape as ``coords``, and matching type to the array.
+        Returns: ``self``, to enable method chaining.
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -348,7 +386,10 @@ SparseArrowData = Union[
 
 
 class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
-    """A N-dimensional array stored sparsely. [lifecycle: experimental]"""
+    """A N-dimensional array stored sparsely.
+
+    Lifecycle: experimental
+    """
 
     __slots__ = ()
     soma_type: Final = "SOMASparseNDArray"  # type: ignore[misc]
@@ -364,7 +405,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
         result_order: options.ResultOrderStr = _RO_AUTO,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "SparseRead":
-        """Reads the specified subarray in batches. [lifecycle: experimental]
+        """Reads the specified subarray in batches.
 
         Values returned are a :class:`SparseRead` object which can be converted
         to any number of formats::
@@ -372,14 +413,18 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
             some_dense_array.read(...).tables()
             # -> an iterator of Arrow Tables
 
-        :param coords: A per-dimension sequence of coordinates defining
-            the range to be read.
-        :param batch_size: The size of batches that should be returned
-            from a read. See :class:`options.BatchSize` for details.
-        :param partitions: Specifies that this is part of a partitioned read,
-            and which partition to include, if present.
-        :param result_order: the order to return results, specified as a
-            :class:`~options.ResultOrder` or its string value.
+        Args:
+            coords: A per-dimension sequence of coordinates defining
+                the range to be read.
+            batch_size: The size of batches that should be returned from a read.
+            See :class:`options.BatchSize` for details.
+            partitions: Specifies that this is part of a partitioned read,
+                and which partition to include, if present.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+
+        Returns: The data that was requested in a :class:`SparseRead`,
+            allowing access in any supported format.
 
         **Indexing:**
 
@@ -406,6 +451,8 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
           all indices up to and including the value, and all indices
           starting from and including the value.
         - Negative indexing is not supported.
+
+        Lifecycle: experimental
         """
 
     @abc.abstractmethod
@@ -416,27 +463,30 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> Self:
         """Writes a Tensor to a subarray of the persistent object.
-        [lifecycle: experimental]
 
-        :param values: The values to write to the array.
-        :return: ``self``, to enable method chaining.
+        Args:
+            values: The values to write to the array. Supported types are:
 
-        **Value types:**
+                Arrow sparse tensor: the coordinates in the tensor are
+                interpreted as the coordinates to write to.  Supports the
+                *experimental* types SparseCOOTensor, SparseCSRMatrix, and
+                SparseCSCMatrix. There is currently no support for
+                SparseCSFTensor or dense Tensor.
 
-        Arrow sparse tensor: the coordinates in the tensor are interpreted as
-        the coordinates to write to.  Supports the *experimental* types
-        SparseCOOTensor, SparseCSRMatrix and SparseCSCMatrix. There is currently
-        no support for Arrow SparseCSFTensor or dense Tensor.
+                Arrow table: a COO table, with columns named ``soma_dim_0``,
+                    ..., ``soma_dim_N`` and ``soma_data``.
 
-        Arrow table: a COO table, with columns named ``soma_dim_0``, ...,
-        ``soma_dim_N`` and ``soma_data``, to be written to the array.
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
     @property
     def nnz(self) -> int:
         """The number of values stored in the array, including explicit zeros.
-        [lifecycle: experimental]
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
@@ -453,7 +503,8 @@ _T = TypeVar("_T")
 
 class ReadIter(Iterator[_T], metaclass=abc.ABCMeta):
     """SparseRead result iterator allowing users to flatten the iteration.
-    [lifecycle: experimental]
+
+    Lifecycle: experimental
     """
 
     __slots__ = ()
@@ -464,22 +515,24 @@ class ReadIter(Iterator[_T], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def concat(self) -> _T:
         """Returns all the requested data in a single operation.
-        [lifecycle: experimental]
 
         If some data has already been retrieved using ``next``, this will return
-        the rest of the data after that which has already been returned.
+        the remaining data, excluding that which as already been returned.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 
 
 class SparseRead:
     """Intermediate type to choose result format when reading a sparse array.
-    [lifecycle: experimental]
 
     A query may not be able to return all of these formats. The concrete result
     may raise a ``NotImplementedError`` or may choose to raise a different
     exception (likely a ``TypeError``) containing more specific information
     about why the given format is not supported.
+
+    Lifecycle: experimental
     """
 
     __slots__ = ()

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -18,7 +18,15 @@ _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 
 
 class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _RootSO]):
-    """Mixin for Experiment types [lifecycle: experimental]."""
+    """A collection subtype representing an annotated 2D matrix of measurements.
+
+    In single cell biology, this can represent multiple modes of measurement
+    across a single collection of cells (i.e., a "multimodal dataset").
+    Within an experiment, a set of measurements on a single set of variables
+    (i.e., features) is represented as a :class:`~measurement.Measurement`.
+
+    Lifecycle: experimental
+    """
 
     # This class is implemented as a mixin to be used with SOMA classes.
     # For example, a SOMA implementation would look like this:
@@ -56,9 +64,11 @@ class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _Ro
         obs_query: Optional[query.AxisQuery] = None,
         var_query: Optional[query.AxisQuery] = None,
     ) -> "query.ExperimentAxisQuery[Self]":
-        """Creates an axis query over this experiment [lifecycle: experimental].
+        """Creates an axis query over this experiment.
 
         See :class:`query.ExperimentAxisQuery` for details on usage.
+
+        Lifecycle: experimental
         """
         # mypy doesn't quite understand descriptors so it issues a spurious
         # error here.

--- a/python-spec/src/somacore/measurement.py
+++ b/python-spec/src/somacore/measurement.py
@@ -27,7 +27,19 @@ class Measurement(
     collection.BaseCollection[_RootSO],
     Generic[_DF, _NDColl, _DenseNDColl, _SparseNDColl, _RootSO],
 ):
-    """A set of observations defined by a DataFrame, with measurements."""
+    """A set of observations defined by a dataframe, with measurements.
+
+    This is a common set of annotated variables (defined by the ``var``
+    dataframe) for which values (e.g., measurements or calculations) are stored
+    in sparse and dense ND arrays.
+
+    The observables are inherited from the parent ``Experiment``'s
+    ``obs`` dataframe. The ``soma_joinid`` of these observables (``obsid``),
+    along with those of the measurement's ``var`` dataframe (``varid``),
+    are the indices for all the other matrices stored in the measurement.
+
+    Lifecycle: experimental
+    """
 
     # This class is implemented as a mixin to be used with SOMA classes.
     # For example, a SOMA implementation would look like this:

--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -1,12 +1,17 @@
-"""Type and interface declarations that are not specific to options."""
+"""Type and interface declarations that are not specific to options.
+
+These declarations and functions are not directly part of the user-facing API,
+but are intended to be used by SOMA implementations for annotations and
+their own internal type-checking purposes.
+"""
 
 import sys
-from typing import TYPE_CHECKING, Any, NoReturn, Optional, Sequence, Type, TypeVar
+from typing import TYPE_CHECKING, NoReturn, Optional, Sequence, Type, TypeVar
 
 from typing_extensions import Protocol, TypeGuard
 
 
-def is_nonstringy_sequence(it: Any) -> TypeGuard[Sequence]:
+def is_nonstringy_sequence(it: object) -> TypeGuard[Sequence]:
     """Returns true if a sequence is a "normal" sequence and not str or bytes.
 
     str and bytes are "weird" sequences because iterating them gives you


### PR DESCRIPTION
This also expands the docstrings for Experiment and Measurement.

---

In this change, I also changed the format of maturity levels to make them look like just another docs stanza. If we don’t like it, it can be reverted to the `[lifecycle: whatever]` style.

Part of https://github.com/single-cell-data/TileDB-SOMA/issues/974.