### PR TITLE
Add initial directory and README for SOMA RFCs/design docs.

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,3 @@
+# SOMA RFCs
+
+This directory contains all Request-For-Comments (RFCs) that have been generated in order to capture technical design decisions and discussions that have happened as part of developing SOMA and its implementations. Implementation specific design docs (e.g. RFCs that capture decisions or discussions about TileDB-SOMA) can be found in their respective Github repositories (e.g. https://www.github.com/single-cell-data/TileDB-SOMA).


### PR DESCRIPTION
This directory can be used to capture design documents and proposals about the SOMA spec and can be used as a source of truth to revisit technical decisions in a central location. 