### PR TITLE
[Python] update lifecycle tags

### DIFF
--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -36,7 +36,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
             platform_config: Platform configuration options specific to
                 this open operation.
         Returns: The SOMA object, opened for reading.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -51,7 +51,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
         Returns:
             True if the object exists and is of the correct type.
             False if the object does not exist, or is of a different type.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -60,7 +60,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
     def uri(self) -> str:
         """The URI of this SOMA object.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -76,7 +76,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
         from an existing SOMA object to be used in the creation of a new SOMA
         object, it should not be inspected.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return None
 
@@ -89,7 +89,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
         and writes to it (provided the object is opened) are reflected in
         storage.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -98,7 +98,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
     def mode(self) -> options.OpenMode:
         """Returns the mode this object was opened in, either ``r`` or ``w``.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -107,7 +107,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
     def closed(self) -> bool:
         """True if this object has been closed; False if still open.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -132,7 +132,7 @@ class SOMAObject(metaclass=abc.ABCMeta):
         ``__del__`` when this object is garbage collected, so the implementation
         must be idempotent.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         # Default implementation does nothing.
 

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -23,7 +23,7 @@ class BaseCollection(
     most generic, a Collection may contain any SOMA object, but a subclass
     may specify that it is a Collection of a specific type of SOMA object.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()
@@ -43,7 +43,7 @@ class BaseCollection(
             uri: The URI where the collection will be created.
         Returns:
             The newly created collection, opened for writing.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -135,7 +135,7 @@ class BaseCollection(
         Returns:
             The newly created collection, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -157,7 +157,7 @@ class BaseCollection(
         Returns:
             The newly created DataFrame, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -179,7 +179,7 @@ class BaseCollection(
         Returns:
             The newly created dense NDArray, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -201,7 +201,7 @@ class BaseCollection(
         Returns:
             The newly created sparse NDArray, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -242,7 +242,7 @@ class BaseCollection(
 
         Returns: ``self``, to enable method chaining.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -250,7 +250,7 @@ class BaseCollection(
 class Collection(BaseCollection[_Elem]):
     """SOMA Collection imposing no semantics on the contained values.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     soma_type: Final = "SOMACollection"  # type: ignore[misc]

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -30,7 +30,7 @@ _RO_AUTO = options.ResultOrder.AUTO
 class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     """A multi-column table with a user-defined schema.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()
@@ -87,7 +87,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         Returns:
             The newly created dataframe, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -155,7 +155,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
           sequence indexing. For instance, ``slice(-10, 3)`` indicates the range
           from −10 to 3 on the given dimension.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -178,7 +178,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
 
         Returns: ``self``, to enable method chaining.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -189,7 +189,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     def schema(self) -> pa.Schema:
         """The schema of the data in this dataframe.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -198,7 +198,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     def index_column_names(self) -> Tuple[str, ...]:
         """The names of the index (dimension) columns.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -210,7 +210,7 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         Returns: a tuple of minimum and maximum values, inclusive,
             storable on each index column of the dataframe.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -252,7 +252,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
 
         Returns: The newly created array, opened for writing.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -263,7 +263,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     def shape(self) -> Tuple[int, ...]:
         """The maximum capacity (domain) of each dimension of this array.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -271,7 +271,7 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     def ndim(self) -> int:
         """The number of dimensions in this array.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return len(self.shape)
 
@@ -280,14 +280,14 @@ class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     def schema(self) -> pa.Schema:
         """The schema of the data in this array.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
     is_sparse: ClassVar[Literal[True, False]]
     """True if the array is sparse, False if it is dense.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
 
@@ -295,7 +295,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
     """
     An N-dimensional array stored densely.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()
@@ -351,7 +351,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
           starting from and including the value.
         - Negative indexing is not supported.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -375,7 +375,7 @@ class DenseNDArray(NDArray, metaclass=abc.ABCMeta):
             values: The values to be written to the subarray.  Must have
                 the same shape as ``coords``, and matching type to the array.
         Returns: ``self``, to enable method chaining.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -392,7 +392,7 @@ SparseArrowData = Union[
 class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
     """A N-dimensional array stored sparsely.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()
@@ -456,7 +456,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
           starting from and including the value.
         - Negative indexing is not supported.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
 
     @abc.abstractmethod
@@ -482,7 +482,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
 
         Returns: ``self``, to enable method chaining.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -490,7 +490,7 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
     def nnz(self) -> int:
         """The number of values stored in the array, including explicit zeros.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -508,7 +508,7 @@ _T = TypeVar("_T")
 class ReadIter(Iterator[_T], metaclass=abc.ABCMeta):
     """SparseRead result iterator allowing users to flatten the iteration.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()
@@ -523,7 +523,7 @@ class ReadIter(Iterator[_T], metaclass=abc.ABCMeta):
         If some data has already been retrieved using ``next``, this will return
         the remaining data, excluding that which as already been returned.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         raise NotImplementedError()
 
@@ -536,7 +536,7 @@ class SparseRead:
     exception (likely a ``TypeError``) containing more specific information
     about why the given format is not supported.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     __slots__ = ()

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -25,7 +25,7 @@ class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _Ro
     Within an experiment, a set of measurements on a single set of variables
     (i.e., features) is represented as a :class:`~measurement.Measurement`.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     # This class is implemented as a mixin to be used with SOMA classes.
@@ -68,7 +68,7 @@ class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _Ro
 
         See :class:`query.ExperimentAxisQuery` for details on usage.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         # mypy doesn't quite understand descriptors so it issues a spurious
         # error here.

--- a/python-spec/src/somacore/measurement.py
+++ b/python-spec/src/somacore/measurement.py
@@ -38,7 +38,7 @@ class Measurement(
     along with those of the measurement's ``var`` dataframe (``varid``),
     are the indices for all the other matrices stored in the measurement.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     # This class is implemented as a mixin to be used with SOMA classes.

--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -78,7 +78,7 @@ class AxisQuery:
         AxisQuery(value_filter="tissue == 'lung'")
         AxisQuery(coords=(slice(1,None),), value_filter="tissue == 'lung'")
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     value_filter: Optional[str] = attrs.field(

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -31,7 +31,7 @@ class AxisColumnNames(TypedDict, total=False):
     """
     Specifies column names for experiment axis query read operations.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     obs: Optional[Sequence[str]]
@@ -74,7 +74,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
     implementation that fulfills the basic APIs. A SOMA implementation may
     include a custom query implementation optimized for its own use.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     def __init__(
@@ -103,7 +103,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_
         iterator.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         obs_query = self._matrix_axis_query.obs
         return self._obs_df.read(
@@ -119,7 +119,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`_
         iterator.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         var_query = self._matrix_axis_query.var
         return self._var_df.read(
@@ -131,14 +131,14 @@ class ExperimentAxisQuery(Generic[_Exp]):
     def obs_joinids(self) -> pa.Array:
         """Returns ``obs`` ``soma_joinids`` as an Arrow array.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._joinids.obs
 
     def var_joinids(self) -> pa.Array:
         """Returns ``var`` ``soma_joinids`` as an Arrow array.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._joinids.var
 
@@ -146,7 +146,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
     def n_obs(self) -> int:
         """The number of ``obs`` axis query results.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return len(self.obs_joinids())
 
@@ -154,7 +154,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
     def n_vars(self) -> int:
         """The number of ``var`` axis query results.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return len(self.var_joinids())
 
@@ -162,7 +162,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
     def indexer(self) -> "AxisIndexer":
         """A ``soma_joinid`` indexer for both ``obs`` and ``var`` axes.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._indexer
 
@@ -172,7 +172,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         Args:
             layer_name: The X layer name to return.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         try:
             x_layer = self._ms.X[layer_name]
@@ -187,14 +187,14 @@ class ExperimentAxisQuery(Generic[_Exp]):
     def obsp(self, layer: str) -> data.SparseRead:
         """Returns an ``obsp`` layer as a sparse read.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._axisp_inner(_Axis.OBS, layer)
 
     def varp(self, layer: str) -> data.SparseRead:
         """Returns an ``varp`` layer as a sparse read.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._axisp_inner(_Axis.VAR, layer)
 
@@ -215,7 +215,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
             X_layers: Additional X layers to read and return
                 in the ``layers`` slot.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._read(
             X_name,
@@ -230,7 +230,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
 
         This method must be idempotent.
 
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         # Because this may be called during ``__del__`` when we might be getting
         # disassembled, sometimes ``_threadpool_`` is simply missing.
@@ -526,7 +526,7 @@ class AxisIndexer:
     """
     Given a query, provides index-building services for obs/var axis.
 
-    Lifecycle: experimental
+    Lifecycle: maturing
     """
 
     query: ExperimentAxisQuery


### PR DESCRIPTION
Related to single-cell-data/TileDB-SOMA#1402

Update public API lifecycle tags from `experimental` to `maturing`

**Note to reviewers:** please consider if there are any exceptions to this update (i.e., API that should remain `experimental`).

See also:  single-cell-data/TileDB-SOMA#1405
