### PR TITLE
Add a note about why the fields of Slice are `@property`s.

### DIFF
--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -35,6 +35,18 @@ class Slice(Protocol[_T_co]):
     ``start``/``stop``/``step`` and would match, but are *not* slices.
     """
 
+    # We use @property here to indicate that these fields are read-only;
+    # just saying::
+    #
+    #     start: Optional[_T_co]
+    #
+    # would imply that doing::
+    #
+    #     some_slice.start = a_new_value
+    #
+    # was valid, thus making mypy whine (correctly!) that _T_co should be
+    # invariant rather than covariant.
+
     @property
     def start(self) -> Optional[_T_co]:
         ...


### PR DESCRIPTION
After talking just now I was looking at the protocol and wondered: Why do we not just say `class Slice(Protocol[_T_co]): start: Optional[_T_co]` etc.? The [`Named` example protocol](https://docs.python.org/3/library/typing.html#typing.runtime_checkable) in the Python docs uses that syntax.

Then I tried it and found out why.