### PR TITLE
Add `pa.ChunkedArray` to `SparseNDCoord` type

### DIFF
--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -174,6 +174,7 @@ SparseNDCoord = Union[
     ValSliceOrSequence[int],
     npt.NDArray[np.integer],
     pa.IntegerArray,
+    pa.ChunkedArray,
 ]
 """A single coordinate range for one dimension of a sparse nd-array."""
 SparseNDCoords = Sequence[SparseNDCoord]


### PR DESCRIPTION
For discussion, cf. https://github.com/single-cell-data/TileDB-SOMA/issues/1791, cc @johnkerl @bkmartinjr.

What more might we want to do here? Existing TileDB-SOMA tests pass with and without this change, see https://github.com/single-cell-data/TileDB-SOMA/pull/2234