### PR TITLE
Remove optional keyword args from `IndexLike.get_indexer`

### DIFF
--- a/python-spec/src/somacore/query/types.py
+++ b/python-spec/src/somacore/query/types.py
@@ -16,13 +16,7 @@ class IndexLike(Protocol):
     not as a full specification of the types and behavior of ``get_indexer``.
     """
 
-    def get_indexer(
-        self,
-        target: npt.NDArray[np.int64],
-        method: object = ...,
-        limit: object = ...,
-        tolerance: object = ...,
-    ) -> Any:
+    def get_indexer(self, target: npt.NDArray[np.int64]) -> Any:
         """Something compatible with Pandas' Index.get_indexer method."""
 
 


### PR DESCRIPTION
We only use the `target` positional argument from the pandas `Index.get_indexer` method. Remove optional keyword arguments to allow greater flexibility when implementing a `IndexLike` class.