### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/python-somacore.yaml
+++ b/.github/workflows/python-somacore.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "scipy",
   "typing-extensions>=4.1", # For LiteralString
 ]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 urls = { repository = "https://github.com/single-cell-data/SOMA.git" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 

--- a/python-spec/update-requirements-txt
+++ b/python-spec/update-requirements-txt
@@ -12,7 +12,7 @@ trap "trash $TEMPDIR" EXIT
 # The version of Python we want to run lints under.
 LINTVER=3.8
 
-for PYVER in 3.7 3.8 3.9 3.10 3.11 3.12; do
+for PYVER in 3.8 3.9 3.10 3.11 3.12; do
   CONDIR="$TEMPDIR/py-$PYVER"
   conda create -y -p "$CONDIR" "python=$PYVER"
   (


### PR DESCRIPTION
Following on
* https://github.com/single-cell-data/TileDB-SOMA/pull/2181
* https://github.com/single-cell-data/TileDB-SOMA/issues/1790

We should have done the same for this repo, and did not