### PR TITLE
(WIP) Add spatial support to a standard ExperimentAxisQuery

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -16,6 +16,9 @@ import pyarrow_hotfix
 
 from .base import SOMAObject
 from .collection import Collection
+from .coordinates import Axis
+from .coordinates import CoordinateSystem
+from .coordinates import CoordinateTransform
 from .data import DataFrame
 from .data import DenseNDArray
 from .data import NDArray
@@ -63,4 +66,7 @@ __all__ = (
     "AxisQuery",
     "ExperimentAxisQuery",
     "ContextBase",
+    "Axis",
+    "CoordinateSystem",
+    "CoordinateTransform",
 )

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -1,0 +1,50 @@
+"""Definitions of types related to coordinate systems."""
+
+
+import abc
+from typing import Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+class Axis(metaclass=abc.ABCMeta):
+    """A description of an axis of a coordinate system
+
+    Lifecycle: experimental
+    """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """TODO: Add docstring for Axis.name"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def type(self) -> Optional[str]:
+        """TODO: Add docstring for Axis.type"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def unit(self) -> Optional[str]:
+        """TODO: Add docstring for Axis.unit"""
+        raise NotImplementedError()
+
+
+class CoordinateSystem(metaclass=abc.ABCMeta):
+    """A coordinate system for spatial data."""
+
+    @property
+    @abc.abstractmethod
+    def axes(self) -> Tuple[Axis, ...]:
+        """TODO: Add docstring for CoordinateSystem.axes"""
+        raise NotImplementedError()
+
+
+class CoordinateTransform(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def to_numpy(self) -> npt.NDArray[np.float64]:
+        """TODO: Add docstring for Transformation.to_numpy"""
+        raise NotImplementedError()

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -1,9 +1,10 @@
-from typing import Any, Dict, Iterator, NoReturn, Optional, TypeVar
+from typing import Any, Dict, Iterator, MutableMapping, NoReturn, Optional, TypeVar
 
 from typing_extensions import Literal, Self
 
 from .. import base
 from .. import collection
+from .. import coordinates
 from .. import data
 from .. import experiment
 from .. import measurement
@@ -141,6 +142,16 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     """An in-memory Collection with Scene semantics."""
 
     __slots__ = ()
+
+    @property
+    def local_coordinate_system(self) -> coordinates.CoordinateSystem:
+        """Coordinate system for this scene."""
+        raise NotImplementedError()
+
+    @property
+    def transformations(self) -> MutableMapping[str, coordinates.CoordinateTransform]:
+        """Transformations saved for this scene."""
+        raise NotImplementedError()
 
 
 class Experiment(  # type: ignore[misc]  # __eq__ false positive

--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -1,12 +1,14 @@
 """Implementation of the SOMA scene collection for spatial data"""
 
-from typing import Generic, TypeVar
+import abc
+from typing import Generic, MutableMapping, TypeVar
 
 from typing_extensions import Final
 
 from . import _mixin
 from . import base
 from . import collection
+from . import coordinates
 from . import data
 
 _SpatialDF = TypeVar(
@@ -102,3 +104,15 @@ class Scene(
     This collection exists to store any spatial data in the scene that joins on the var
     ``soma_joinid``.
     """
+
+    @property
+    @abc.abstractmethod
+    def local_coordinate_system(self) -> coordinates.CoordinateSystem:
+        """Coordinate system for this scene."""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def transformations(self) -> MutableMapping[str, coordinates.CoordinateTransform]:
+        """Transformations saved for this scene."""
+        raise NotImplementedError()


### PR DESCRIPTION
This PR adds support for querying spatial data by obs/var.

Done:
* Query `obsl` dataframe

To do:
* Query `scene_id` from `ExperimentAxisQuery`
* Query `obssm` dataframe
* Query `varssm` dataframe
* Query `varl/[measure]` dataframe
* Query images