### PR TITLE
Add first pass at obs/var to scene implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,5 @@ warn_redundant_casts = true
 
 [[tool.mypy.overrides]]
 # These dependencies do not currently have canonical type stubs.
-module = ["anndata", "numba", "pandas", "pyarrow", "pyarrow_hotfix", "scipy"]
+module = ["anndata", "numba", "pandas", "pyarrow", "pyarrow.compute", "pyarrow_hotfix", "scipy"]
 ignore_missing_imports = true


### PR DESCRIPTION
This is a prototype implementation for getting scene IDs from the obs or var index on an experiment query axis for testing purposes.

Issue: [#2592](https://github.com/single-cell-data/TileDB-SOMA/issues/2592)