### PR TITLE
Python spec for geometry dataframe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   # Remove this once we can specify a recent pyarrow.
   "pyarrow-hotfix",
   "scipy",
+  "shapely",
   "typing-extensions>=4.1", # For LiteralString (py3.11)
 ]
 requires-python = "~=3.8"
@@ -62,5 +63,5 @@ python_version = 3.8
 
 [[tool.mypy.overrides]]
 # These dependencies do not currently have canonical type stubs.
-module = ["anndata", "pyarrow", "pyarrow.compute", "pyarrow_hotfix", "scipy"]
+module = ["anndata", "pyarrow", "pyarrow.compute", "pyarrow_hotfix", "scipy", "shapely"]
 ignore_missing_imports = true

--- a/python-spec/requirements-py3.10.txt
+++ b/python-spec/requirements-py3.10.txt
@@ -14,6 +14,7 @@ pyarrow-hotfix==0.6
 python-dateutil==2.9.0.post0
 pytz==2024.1
 scipy==1.13.1
+shapely==2.0.4
 six==1.16.0
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/python-spec/requirements-py3.11.txt
+++ b/python-spec/requirements-py3.11.txt
@@ -12,6 +12,7 @@ pyarrow==16.1.0
 pyarrow-hotfix==0.6
 python-dateutil==2.9.0.post0
 pytz==2024.1
+shapely==2.0.4
 scipy==1.13.1
 six==1.16.0
 typing_extensions==4.12.2

--- a/python-spec/requirements-py3.12.txt
+++ b/python-spec/requirements-py3.12.txt
@@ -14,6 +14,7 @@ python-dateutil==2.9.0.post0
 pytz==2024.1
 scipy==1.13.1
 setuptools==70.0.0
+shapely==2.0.4
 six==1.16.0
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/python-spec/requirements-py3.8-lint.txt
+++ b/python-spec/requirements-py3.8-lint.txt
@@ -29,6 +29,7 @@ pytz==2024.1
 PyYAML==6.0.1
 ruff==0.4.9
 scipy==1.10.1
+shapely==2.0.4
 six==1.16.0
 tomli==2.0.1
 types-pytz==2024.1.0.20240417

--- a/python-spec/requirements-py3.8.txt
+++ b/python-spec/requirements-py3.8.txt
@@ -13,6 +13,7 @@ pyarrow-hotfix==0.6
 python-dateutil==2.9.0.post0
 pytz==2024.1
 scipy==1.10.1
+shapely==2.0.4
 six==1.16.0
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/python-spec/requirements-py3.9.txt
+++ b/python-spec/requirements-py3.9.txt
@@ -18,6 +18,7 @@ pytz==2024.1
 rsa==4.7.2
 s3transfer==0.6.0
 scipy==1.13.1
+shapely==2.0.4
 six==1.16.0
 typing_extensions==4.12.2
 tzdata==2024.1

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -21,7 +21,9 @@ from .coordinates import CoordinateSystem
 from .coordinates import CoordinateTransform
 from .data import DataFrame
 from .data import DenseNDArray
+from .data import GeometryDataFrame
 from .data import NDArray
+from .data import PointCloud
 from .data import ReadIter
 from .data import SparseNDArray
 from .data import SparseRead
@@ -63,6 +65,8 @@ __all__ = (
     "Scene",
     "ImageCollection",
     "Image2DCollection",
+    "PointCloud",
+    "GeometryDataFrame",
     "BatchSize",
     "IOfN",
     "ResultOrder",

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -27,6 +27,7 @@ from .data import PointCloud
 from .data import ReadIter
 from .data import SparseNDArray
 from .data import SparseRead
+from .data import SpatialDataFrame
 from .experiment import Experiment
 from .images import Image2DCollection
 from .images import ImageCollection
@@ -65,6 +66,7 @@ __all__ = (
     "Scene",
     "ImageCollection",
     "Image2DCollection",
+    "SpatialDataFrame",
     "PointCloud",
     "GeometryDataFrame",
     "BatchSize",

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -215,163 +215,6 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class PointCloud(DataFrame, metaclass=abc.ABCMeta):
-    """A multi-column table with point data and a user-defined schema.
-
-    Lifecycle: experimental
-    """
-
-    __slots__ = ()
-    soma_type: Final = "SOMAPointCloud"  # type: ignore[misc]
-
-    @classmethod
-    @abc.abstractmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        schema: pa.Schema,
-        index_column_names: Sequence[str] = (options.SOMA_JOINID, "x", "y"),
-        spatial_column_names: Sequence[str] = ("x", "y"),
-        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[Any] = None,
-    ) -> Self:
-        """Creates a new ``PointCloud`` at the given URI.
-
-        The schema of the created point cloud  will include a column named
-        ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
-        at least one spatial column with numeric type.  If a ``soma_joinid`` column is
-        present in the provided schema, it must be of the correct type.  If the
-        ``soma_joinid`` column is not provided, one will be added. The ``soma_joinid``
-        may be an index column. The spatial columns must be index columns.
-
-        Args:
-            uri: The URI where the dataframe will be created.
-
-            schema: Arrow schema defining the per-column schema. This schema
-                must define all columns, including columns to be named as index
-                columns.  If the schema includes types unsupported by the SOMA
-                implementation, an error will be raised.
-
-            index_column_names: A list of column names to use as user-defined index
-                columns (e.g., ``['x', 'y']``). All named columns must exist in the
-                schema, and at least one index column name is required.
-
-            spatial_column_names: An ordered list of spatial column names that
-                coorespond to the names of axes of the the coordinate space the points
-                are defined on.
-
-            domain: An optional sequence of tuples specifying the domain of each
-                index column. Each tuple should be a pair consisting of the minimum
-                and maximum values storable in the index column. If omitted entirely,
-                or if ``None`` in a given dimension, the corresponding index-column
-                domain will use the minimum and maximum possible values for the
-                column's datatype.  This makes a point cloud dataframe growable.
-
-        Returns:
-            The newly created geometry dataframe, opened for writing.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    # Metadata operations
-
-    @property
-    @abc.abstractmethod
-    def spatial_column_names(self) -> Tuple[str, ...]:
-        """The names of the spatial columns.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-
-class GeometryDataFrame(DataFrame, metaclass=abc.ABCMeta):
-    """A multi-column table of geometries with spatial indexing and a user-defined
-    schema.
-
-    Lifecycle: experimental
-    """
-
-    __slots__ = ()
-    soma_type: Final = "SOMAGeometryDataFrame"  # type: ignore[misc]
-
-    # Lifecycle
-
-    @classmethod
-    @abc.abstractmethod
-    def create(
-        cls,
-        uri: str,
-        *,
-        schema: pa.Schema,
-        index_column_names: Sequence[str] = (
-            options.SOMA_JOINID,
-            options.SOMA_GEOMETRY,
-        ),
-        spatial_column_names: Sequence[str] = ("x", "y"),
-        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-        context: Optional[Any] = None,
-    ) -> Self:
-        """Creates a new ``GeometryDataFrame`` at the given URI.
-
-        The schema of the created geoemetry dataframe will include a column named
-        ``soma_joinid`` of type ``pyarrow.int64``, with negative values
-        disallowed, and a column named ``soma_geometry of type ``pyarrow.binary`` or
-        ``pyarrow.large_binary``.  If a ``soma_joinid`` column or ``soma_geometry``
-        are present in the provided schema, they must be of the correct type.  If
-        either the ``soma_joinid`` column or ``soma_geometry`` column are not provided,
-        one will be added. The ``soma_joinid`` may be an index column. The
-        ``soma_geometry`` column must be an index column.
-
-        Args:
-            uri: The URI where the dataframe will be created.
-
-            schema: Arrow schema defining the per-column schema. This schema
-                must define all columns, including columns to be named as index
-                columns.  If the schema includes types unsupported by the SOMA
-                implementation, an error will be raised.
-
-            index_column_names: A list of column names to use as user-defined
-                index columns (e.g., ``['cell_type', 'tissue_type']``).
-                All named columns must exist in the schema, and at least one
-                index column name is required.
-
-            spatial_column_names: An ordered list of spatial column names that
-                coorespond to the names of the axes of the coordinate space the
-                geometries are defined on.
-
-            domain: An optional sequence of tuples specifying the domain of each
-                index column. Two tuples must be provided for the ``soma_geometry``
-                column which store the width followed by the height. Each tuple should
-                be a pair consisting of the minimum and maximum values storable in the
-                index column. If omitted entirely, or if ``None`` in a given dimension,
-                the corresponding index-column domain will use the minimum and maximum
-                possible values for the column's datatype.  This makes a dataframe
-                growable.
-
-        Returns:
-            The newly created geometry dataframe, opened for writing.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    # Metadata operations
-
-    @property
-    @abc.abstractmethod
-    def spatial_column_names(self) -> Tuple[str, ...]:
-        """The names of the spatial columns.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-
 class NDArray(base.SOMAObject, metaclass=abc.ABCMeta):
     """Common behaviors of N-dimensional arrays of a single primitive type."""
 
@@ -648,6 +491,252 @@ class SparseNDArray(NDArray, metaclass=abc.ABCMeta):
         """The number of values stored in the array, including explicit zeros.
 
         Lifecycle: maturing
+        """
+        raise NotImplementedError()
+
+
+class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
+    """A multi-column table with spatial indexing and a user-defined schema.
+
+    Lifecycle: experimental
+    """
+
+    __slots__ = ()
+
+    # Data operations
+
+    # TODO: Update this to take spatial input and return output with
+    # coords, etc.
+    @abc.abstractmethod
+    def read(
+        self,
+        coords: options.SparseDFCoords = (),
+        column_names: Optional[Sequence[str]] = None,
+        *,
+        batch_size: options.BatchSize = options.BatchSize(),
+        partitions: Optional[options.ReadPartitions] = None,
+        result_order: options.ResultOrderStr = _RO_AUTO,
+        value_filter: Optional[str] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> "ReadIter[pa.Table]":
+        """Reads a user-defined slice of data into Arrow tables.
+
+        Args:
+            coords: for each index dimension, which rows to read.
+                Defaults to ``()``, meaning no constraint -- all IDs.
+            column_names: the named columns to read and return.
+                Defaults to ``None``, meaning no constraint -- all column names.
+            partitions: If present, specifies that this is part of
+                a partitioned read, and which part of the data to include.
+            result_order: the order to return results, specified as a
+                :class:`~options.ResultOrder` or its string value.
+            value_filter: an optional value filter to apply to the results.
+                The default of ``None`` represents no filter. Value filter
+                syntax is implementation-defined; see the documentation
+                for the particular SOMA implementation for details.
+        Returns:
+            A :class:`ReadIter` of :class:`pa.Table`s.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def write(
+        self,
+        values: Union[pa.RecordBatch, pa.Table],
+        *,
+        platform_config: Optional[options.PlatformConfig] = None,
+    ) -> Self:
+        """Writes the data from an Arrow table to the persistent object.
+
+        As duplicate index values are not allowed, index values already present
+        in the object are overwritten and new index values are added.
+
+        Args:
+            values: An Arrow table containing all columns, including
+                the index columns. The schema for the values must match
+                the schema for the ``DataFrame``.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    # Metadata operations
+
+    @property
+    @abc.abstractmethod
+    def schema(self) -> pa.Schema:
+        """The schema of the data in this dataframe.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def index_column_names(self) -> Tuple[str, ...]:
+        """The names of the index (dimension) columns.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def spatial_column_names(self) -> Tuple[str, ...]:
+        """The names of the spatial columns.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
+        """The allowable range of values in each index column.
+
+        Returns: a tuple of minimum and maximum values, inclusive,
+            storable on each index column of the dataframe.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+
+class PointCloud(SpatialDataFrame, metaclass=abc.ABCMeta):
+    """A multi-column table with point data and a user-defined schema.
+
+    Lifecycle: experimental
+    """
+
+    __slots__ = ()
+    soma_type: Final = "SOMAPointCloud"  # type: ignore[misc]
+
+    @classmethod
+    @abc.abstractmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (options.SOMA_JOINID, "x", "y"),
+        spatial_column_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> Self:
+        """Creates a new ``PointCloud`` at the given URI.
+
+        The schema of the created point cloud  will include a column named
+        ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
+        at least one spatial column with numeric type.  If a ``soma_joinid`` column is
+        present in the provided schema, it must be of the correct type.  If the
+        ``soma_joinid`` column is not provided, one will be added. The ``soma_joinid``
+        may be an index column. The spatial columns must be index columns.
+
+        Args:
+            uri: The URI where the dataframe will be created.
+
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
+
+            index_column_names: A list of column names to use as user-defined index
+                columns (e.g., ``['x', 'y']``). All named columns must exist in the
+                schema, and at least one index column name is required.
+
+            spatial_column_names: An ordered list of spatial column names that
+                coorespond to the names of axes of the the coordinate space the points
+                are defined on.
+
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Each tuple should be a pair consisting of the minimum
+                and maximum values storable in the index column. If omitted entirely,
+                or if ``None`` in a given dimension, the corresponding index-column
+                domain will use the minimum and maximum possible values for the
+                column's datatype.  This makes a point cloud dataframe growable.
+
+        Returns:
+            The newly created geometry dataframe, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+
+class GeometryDataFrame(SpatialDataFrame, metaclass=abc.ABCMeta):
+    """A multi-column table of geometries with spatial indexing and a user-defined
+    schema.
+
+    Lifecycle: experimental
+    """
+
+    __slots__ = ()
+    soma_type: Final = "SOMAGeometryDataFrame"  # type: ignore[misc]
+
+    # Lifecycle
+
+    @classmethod
+    @abc.abstractmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (
+            options.SOMA_JOINID,
+            options.SOMA_GEOMETRY,
+        ),
+        spatial_column_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> Self:
+        """Creates a new ``GeometryDataFrame`` at the given URI.
+
+        The schema of the created geoemetry dataframe will include a column named
+        ``soma_joinid`` of type ``pyarrow.int64``, with negative values
+        disallowed, and a column named ``soma_geometry of type ``pyarrow.binary`` or
+        ``pyarrow.large_binary``.  If a ``soma_joinid`` column or ``soma_geometry``
+        are present in the provided schema, they must be of the correct type.  If
+        either the ``soma_joinid`` column or ``soma_geometry`` column are not provided,
+        one will be added. The ``soma_joinid`` may be an index column. The
+        ``soma_geometry`` column must be an index column.
+
+        Args:
+            uri: The URI where the dataframe will be created.
+
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
+
+            index_column_names: A list of column names to use as user-defined
+                index columns (e.g., ``['cell_type', 'tissue_type']``).
+                All named columns must exist in the schema, and at least one
+                index column name is required.
+
+            spatial_column_names: An ordered list of spatial column names that
+                coorespond to the names of the axes of the coordinate space the
+                geometries are defined on.
+
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Two tuples must be provided for the ``soma_geometry``
+                column which store the width followed by the height. Each tuple should
+                be a pair consisting of the minimum and maximum values storable in the
+                index column. If omitted entirely, or if ``None`` in a given dimension,
+                the corresponding index-column domain will use the minimum and maximum
+                possible values for the column's datatype.  This makes a dataframe
+                growable.
+
+        Returns:
+            The newly created geometry dataframe, opened for writing.
+
+        Lifecycle: experimental
         """
         raise NotImplementedError()
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -586,8 +586,8 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def spatial_column_names(self) -> Tuple[str, ...]:
-        """The names of the spatial columns.
+    def axis_names(self) -> Tuple[str, ...]:
+        """The names of the axes of the coordinate space the data is defined on.
 
         Lifecycle: experimental
         """
@@ -623,7 +623,7 @@ class PointCloud(SpatialDataFrame, metaclass=abc.ABCMeta):
         *,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID, "x", "y"),
-        spatial_column_names: Sequence[str] = ("x", "y"),
+        axis_names: Sequence[str] = ("x", "y"),
         domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
@@ -632,10 +632,10 @@ class PointCloud(SpatialDataFrame, metaclass=abc.ABCMeta):
 
         The schema of the created point cloud  will include a column named
         ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
-        at least one spatial column with numeric type.  If a ``soma_joinid`` column is
+        at least one axis with numeric type.  If a ``soma_joinid`` column is
         present in the provided schema, it must be of the correct type.  If the
         ``soma_joinid`` column is not provided, one will be added. The ``soma_joinid``
-        may be an index column. The spatial columns must be index columns.
+        may be an index column. The axis columns must be index columns.
 
         Args:
             uri: The URI where the dataframe will be created.
@@ -649,7 +649,7 @@ class PointCloud(SpatialDataFrame, metaclass=abc.ABCMeta):
                 columns (e.g., ``['x', 'y']``). All named columns must exist in the
                 schema, and at least one index column name is required.
 
-            spatial_column_names: An ordered list of spatial column names that
+            axis_names: An ordered list of axis column names that
                 coorespond to the names of axes of the the coordinate space the points
                 are defined on.
 
@@ -691,7 +691,7 @@ class GeometryDataFrame(SpatialDataFrame, metaclass=abc.ABCMeta):
             options.SOMA_JOINID,
             options.SOMA_GEOMETRY,
         ),
-        spatial_column_names: Sequence[str] = ("x", "y"),
+        axis_names: Sequence[str] = ("x", "y"),
         domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
@@ -720,7 +720,7 @@ class GeometryDataFrame(SpatialDataFrame, metaclass=abc.ABCMeta):
                 All named columns must exist in the schema, and at least one
                 index column name is required.
 
-            spatial_column_names: An ordered list of spatial column names that
+            axis_names: An ordered list of axis column names that
                 coorespond to the names of the axes of the coordinate space the
                 geometries are defined on.
 

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -215,8 +215,82 @@ class DataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
-    """A multi-column table with a user-defined schema.
+class PointCloud(DataFrame, metaclass=abc.ABCMeta):
+    """A multi-column table with point data and a user-defined schema.
+
+    Lifecycle: experimental
+    """
+
+    __slots__ = ()
+    soma_type: Final = "SOMAPointCloud"  # type: ignore[misc]
+
+    @classmethod
+    @abc.abstractmethod
+    def create(
+        cls,
+        uri: str,
+        *,
+        schema: pa.Schema,
+        index_column_names: Sequence[str] = (options.SOMA_JOINID, "x", "y"),
+        spatial_column_names: Sequence[str] = ("x", "y"),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
+        platform_config: Optional[options.PlatformConfig] = None,
+        context: Optional[Any] = None,
+    ) -> Self:
+        """Creates a new ``PointCloud`` at the given URI.
+
+        The schema of the created point cloud  will include a column named
+        ``soma_joinid`` of type ``pyarrow.int64``, with negative values disallowed, and
+        at least one spatial column with numeric type.  If a ``soma_joinid`` column is
+        present in the provided schema, it must be of the correct type.  If the
+        ``soma_joinid`` column is not provided, one will be added. The ``soma_joinid``
+        may be an index column. The spatial columns must be index columns.
+
+        Args:
+            uri: The URI where the dataframe will be created.
+
+            schema: Arrow schema defining the per-column schema. This schema
+                must define all columns, including columns to be named as index
+                columns.  If the schema includes types unsupported by the SOMA
+                implementation, an error will be raised.
+
+            index_column_names: A list of column names to use as user-defined index
+                columns (e.g., ``['x', 'y']``). All named columns must exist in the
+                schema, and at least one index column name is required.
+
+            spatial_column_names: An ordered list of spatial column names that
+                coorespond to the names of axes of the the coordinate space the points
+                are defined on.
+
+            domain: An optional sequence of tuples specifying the domain of each
+                index column. Each tuple should be a pair consisting of the minimum
+                and maximum values storable in the index column. If omitted entirely,
+                or if ``None`` in a given dimension, the corresponding index-column
+                domain will use the minimum and maximum possible values for the
+                column's datatype.  This makes a point cloud dataframe growable.
+
+        Returns:
+            The newly created geometry dataframe, opened for writing.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    # Metadata operations
+
+    @property
+    @abc.abstractmethod
+    def spatial_column_names(self) -> Tuple[str, ...]:
+        """The names of the spatial columns.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+
+class GeometryDataFrame(DataFrame, metaclass=abc.ABCMeta):
+    """A multi-column table of geometries with spatial indexing and a user-defined
+    schema.
 
     Lifecycle: experimental
     """
@@ -226,11 +300,6 @@ class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
 
     # Lifecycle
 
-    # TODO: Things to consider
-    # 1. Need to specify types for (x, y) envelope coordinate bounding box
-    # 2. Need way to specify max possibly domain for (x, y)
-    # 3. Need a way to enforce max possible domain or message the it's for
-    # the envelope?
     @classmethod
     @abc.abstractmethod
     def create(
@@ -242,6 +311,7 @@ class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
             options.SOMA_JOINID,
             options.SOMA_GEOMETRY,
         ),
+        spatial_column_names: Sequence[str] = ("x", "y"),
         domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
@@ -270,6 +340,10 @@ class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
                 All named columns must exist in the schema, and at least one
                 index column name is required.
 
+            spatial_column_names: An ordered list of spatial column names that
+                coorespond to the names of the axes of the coordinate space the
+                geometries are defined on.
+
             domain: An optional sequence of tuples specifying the domain of each
                 index column. Two tuples must be provided for the ``soma_geometry``
                 column which store the width followed by the height. Each tuple should
@@ -286,134 +360,12 @@ class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
-    # Data operations
-
-    @abc.abstractmethod
-    def read(
-        self,
-        coords: options.SparseDFCoords = (),
-        column_names: Optional[Sequence[str]] = None,
-        *,
-        batch_size: options.BatchSize = options.BatchSize(),
-        partitions: Optional[options.ReadPartitions] = None,
-        result_order: options.ResultOrderStr = _RO_AUTO,
-        value_filter: Optional[str] = None,
-        platform_config: Optional[options.PlatformConfig] = None,
-    ) -> "ReadIter[pa.Table]":
-        """Reads a user-defined slice of data into Arrow tables.
-
-        Args:
-            coords: for each index dimension, which rows to read.
-                Defaults to ``()``, meaning no constraint -- all IDs.
-            column_names: the named columns to read and return.
-                Defaults to ``None``, meaning no constraint -- all column names.
-            partitions: If present, specifies that this is part of
-                a partitioned read, and which part of the data to include.
-            result_order: the order to return results, specified as a
-                :class:`~options.ResultOrder` or its string value.
-            value_filter: an optional value filter to apply to the results.
-                The default of ``None`` represents no filter. Value filter
-                syntax is implementation-defined; see the documentation
-                for the particular SOMA implementation for details.
-        Returns:
-            A :class:`ReadIter` of :class:`pa.Table`s.
-
-
-        **Indexing:**
-
-        Indexing is performed on a per-column basis for each indexed column.
-        To specify dimensions:
-
-        - A sequence of coordinates is accepted, one per indexed dimension.
-        - The sequence length must be less than or equal to the number of
-          indexed dimensions.
-        - If the sequence is shorter than the number of indexed coordinates,
-          then no constraint (i.e. ``None``) is used for the remaining
-          indexed dimensions.
-        - If providing a constraint on the ``soma_geometry``, it must either be
-          ``None`` (to specify no constraint) or a ``shapely.GeometryType``
-          object.
-        - Specifying an empty sequence (e.g. ``()``, the default) represents
-          no constraints over any dimension, returning the entire dataset.
-
-        Each dimension other than the ``soma_geometry`` dimension may be indexed
-        as follows:
-
-        - ``None`` or ``slice(None)`` places no constraint on the dimension.
-        - Coordinates can be specified as a scalar value, a Python sequence
-          (``list``, ``tuple``, etc.), a NumPy ndarray, an Arrow array, or
-          similar objects (as defined by ``SparseDFCoords``).
-        - Slices specify a closed range: ``slice(2, 4)`` includes both 2 and 4.
-          Slice *steps* may not be used: ``slice(10, 20, 2)`` is invalid.
-          ``slice(None)`` places no constraint on the dimension. Half-specified
-          slices like ``slice(None, 99)`` and ``slice(5, None)`` specify
-          all indices up to and including the value, and all indices
-          starting from and including the value.
-        - Negative values in indices and slices are treated as raw domain values
-          and not as indices relative to the end, unlike traditional Python
-          sequence indexing. For instance, ``slice(-10, 3)`` indicates the range
-          from −10 to 3 on the given dimension.
-
-        The ``soma_geometry`` dimension may be indexed as follows:
-
-        - ``None`` places no constraint on the dimension.
-        - A query on all intersecting geomemtries can be specified with a
-          ``shapely.GeometryType`` object.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def write(
-        self,
-        values: Union[pa.RecordBatch, pa.Table],
-        *,
-        platform_config: Optional[options.PlatformConfig] = None,
-    ) -> Self:
-        """Writes the data from an Arrow table to the persistent object.
-
-        As duplicate index values are not allowed, index values already present
-        in the object are overwritten and new index values are added.
-
-        Args:
-            values: An Arrow table containing all columns, including
-                the index columns. The schema for the values must match
-                the schema for the ``DataFrame``.
-
-        Returns: ``self``, to enable method chaining.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
     # Metadata operations
 
     @property
     @abc.abstractmethod
-    def schema(self) -> pa.Schema:
-        """The schema of the data in this dataframe.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    @property
-    @abc.abstractmethod
-    def index_column_names(self) -> Tuple[str, ...]:
-        """The names of the index (dimension) columns.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    @property
-    @abc.abstractmethod
-    def domain(self) -> Tuple[Tuple[Any, Any], ...]:
-        """The allowable range of values in each index column.
-
-        Returns: a tuple of minimum and maximum values, inclusive,
-            storable on each index column of the dataframe.
+    def spatial_column_names(self) -> Tuple[str, ...]:
+        """The names of the spatial columns.
 
         Lifecycle: experimental
         """

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -134,7 +134,9 @@ _BasicAbstractMeasurement = measurement.Measurement[
 """The loosest possible constraint of the abstract Measurement type."""
 
 _BasicAbstractScene = scene.Scene[
-    data.DataFrame, images.ImageCollection, base.SOMAObject
+    collection.Collection[data.SpatialDataFrame],
+    images.ImageCollection,
+    base.SOMAObject,
 ]
 """The loosest possible constraint of the abstract Scene type."""
 

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -11,12 +11,16 @@ import attrs
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+import shapely
 from typing_extensions import Final, Literal
 
 from . import types
 
 SOMA_JOINID: Final = "soma_joinid"
 """Global constant for the SOMA join ID."""
+
+SOMA_GEOMETRY: Final = "soma_geometry"
+"""Global constant for SOMA spatial geometry type."""
 
 OpenMode = Literal["r", "w"]
 """How to open a SOMA object: read or write."""
@@ -179,3 +183,8 @@ SparseNDCoord = Union[
 """A single coordinate range for one dimension of a sparse nd-array."""
 SparseNDCoords = Sequence[SparseNDCoord]
 """A sequence of coordinate ranges for reading sparse ndarrays."""
+
+"""A single coordinate range for one dimension of a sparse dataframe."""
+
+GeometryDFCoords = Sequence[Union[SparseNDCoord, shapely.GeometryType]]
+"""A sequence of coordinate ranges for reading dense dataframes."""

--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -12,19 +12,18 @@ from . import coordinates
 from . import data
 from . import images
 
-_SpatialDF = TypeVar(
-    "_SpatialDF", bound=data.DataFrame
-)  # TODO: Update to GeometryDataFrame or PointCloud
-"""A particular implementation of GeometryDataFrame and PointCloud."""
 _ImageColl = TypeVar("_ImageColl", bound=images.ImageCollection)
 """A particular implementation of a collection of spatial arrays."""
+_SpatialDFColl = TypeVar(
+    "_SpatialDFColl", bound=collection.Collection[data.SpatialDataFrame]
+)
 _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 """The root SomaObject type of the implementation."""
 
 
 class Scene(
     collection.BaseCollection[_RootSO],
-    Generic[_SpatialDF, _ImageColl, _RootSO],
+    Generic[_SpatialDFColl, _ImageColl, _RootSO],
 ):
     """TODO: Add documentation for scene
 
@@ -39,7 +38,9 @@ class Scene(
     #     class Scene(  # type: ignore[type-var]
     #         ImplBaseCollection[ImplSOMAObject],
     #         somacore.Scene[
-    #             Union[ImplGeometryDataFrame, ImplPointCloud], # _SpatialDF
+    #             ImplCollection[
+    #                 Union[ImplGeometryDataFrame, ImplPointCloud]]
+    #             ], # _SpatialDFColl
     #             ImplImageCollection,                          # _ImageColl
     #             ImplSOMAObject,                               # _RootSO
     #         ],
@@ -64,7 +65,7 @@ class Scene(
     * Image masks on top of any of the above
     """
 
-    obsl = _mixin.item[collection.Collection[_SpatialDF]]()
+    obsl = _mixin.item[_SpatialDFColl]()
     """A dataframe of the obs locations
 
     This collection exists to store any spatial data in the scene that joins on the obs
@@ -78,7 +79,7 @@ class Scene(
     additional columns may be stored in this dataframe as well.
      """
 
-    varl = _mixin.item[collection.Collection[collection.Collection[_SpatialDF]]]()
+    varl = _mixin.item[collection.Collection[_SpatialDFColl]]()
     """A collection of collections of dataframes of the var locations.
 
     This collection exists to store any spatial data in the scene that joins on the


### PR DESCRIPTION
Changes:
* Add a new GeometryDataFrame class
* Adds shapely as a somacore Python dependency.

WIP:
* How we want to handle the two-dimensional geometry index dimension for both schema specification needs further investigation.

Issues: Closes https://github.com/single-cell-data/TileDB-SOMA/issues/2677