### PR TITLE
Add the new `Scene` collection to the python-spec

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -30,6 +30,7 @@ from .options import ResultOrder
 from .query import AxisColumnNames
 from .query import AxisQuery
 from .query import ExperimentAxisQuery
+from .scene import Scene
 from .types import ContextBase
 
 try:
@@ -54,6 +55,7 @@ __all__ = (
     "SparseRead",
     "Experiment",
     "Measurement",
+    "Scene",
     "BatchSize",
     "IOfN",
     "ResultOrder",

--- a/python-spec/src/somacore/ephemeral/__init__.py
+++ b/python-spec/src/somacore/ephemeral/__init__.py
@@ -8,9 +8,11 @@ Collection.
 from .collections import Collection
 from .collections import Experiment
 from .collections import Measurement
+from .collections import Scene
 
 __all__ = (
     "Collection",
     "Experiment",
     "Measurement",
+    "Scene",
 )

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -8,6 +8,7 @@ from .. import data
 from .. import experiment
 from .. import measurement
 from .. import options
+from .. import scene
 
 _Elem = TypeVar("_Elem", bound=base.SOMAObject)
 
@@ -120,6 +121,11 @@ _BasicAbstractMeasurement = measurement.Measurement[
 ]
 """The loosest possible constraint of the abstract Measurement type."""
 
+_BasicAbstractScene = scene.Scene[
+    data.DataFrame, collection.Collection[data.NDArray], base.SOMAObject
+]
+"""The loosest possible constraint of the abstract Scene type."""
+
 
 class Measurement(  # type: ignore[misc]  # __eq__ false positive
     BaseCollection[base.SOMAObject], _BasicAbstractMeasurement
@@ -129,11 +135,20 @@ class Measurement(  # type: ignore[misc]  # __eq__ false positive
     __slots__ = ()
 
 
+class Scene(  # type: ignore[misc]   # __eq__ false positive
+    BaseCollection[base.SOMAObject], _BasicAbstractScene
+):
+    """An in-memory Collection with Scene semantics."""
+
+    __slots__ = ()
+
+
 class Experiment(  # type: ignore[misc]  # __eq__ false positive
     BaseCollection[base.SOMAObject],
     experiment.Experiment[
         data.DataFrame,
         collection.Collection[_BasicAbstractMeasurement],
+        collection.Collection[_BasicAbstractScene],
         base.SOMAObject,
     ],
 ):

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -8,16 +8,21 @@ from . import collection
 from . import data
 from . import measurement
 from . import query
+from . import scene
 
 _DF = TypeVar("_DF", bound=data.DataFrame)
 """An implementation of a DataFrame."""
 _MeasColl = TypeVar("_MeasColl", bound=collection.Collection[measurement.Measurement])
 """An implementation of a collection of Measurements."""
+_SceneColl = TypeVar("_SceneColl", bound=collection.Collection[scene.Scene])
+"""An implemenation of a collection of spatial data."""
 _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 """The root SOMA object type of the implementation."""
 
 
-class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _RootSO]):
+class Experiment(
+    collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _SceneColl, _RootSO]
+):
     """A collection subtype representing an annotated 2D matrix of measurements.
 
     In single cell biology, this can represent multiple modes of measurement
@@ -38,6 +43,7 @@ class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _Ro
     #         somacore.Experiment[
     #             ImplDataFrame,    # _DF
     #             ImplMeasurement,  # _MeasColl
+    #             ImplScene,        # _SceneColl
     #             ImplSOMAObject,   # _RootSO
     #         ],
     #     ):
@@ -56,6 +62,9 @@ class Experiment(collection.BaseCollection[_RootSO], Generic[_DF, _MeasColl, _Ro
 
     ms = _mixin.item[_MeasColl]()
     """A collection of named measurements."""
+
+    spatial = _mixin.item[_SceneColl]()  # TODO: Discuss the name of this element.
+    """A collection of named spatial scenes."""
 
     def axis_query(
         self,

--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -1,0 +1,78 @@
+"""Implementation of the SOMA scene collection for spatial data"""
+
+from typing import Generic, TypeVar
+
+from typing_extensions import Final
+
+from . import _mixin
+from . import base
+from . import collection
+from . import data
+
+_SpatialDF = TypeVar("_SpatialDF", bound=data.DataFrame)
+"""A particular implementation of GeometryDataFrame and PointCloud."""
+_ImageColl = TypeVar("_ImageColl", bound=collection.Collection[data.NDArray])
+"""A particular implementation of a collection of spatial arrays."""
+_RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
+"""The root SomaObject type of the implementation."""
+
+
+class Scene(
+    collection.BaseCollection[_RootSO],
+    Generic[_SpatialDF, _ImageColl, _RootSO],
+):
+    """A set of spatial data defined on a single physical coordinate system.
+
+    Lifecycle: experimental
+    """
+
+    # This class is implemented as a mixin to be used with SOMA classes.
+    # For example, a SOMA implementation would look like this:
+    #
+    #     # This type-ignore comment will always be needed due to limitations
+    #     # of type annotations; it is (currently) expected.
+    #     class Scene(  # type: ignore[type-var]
+    #         ImplBaseCollection[ImplSOMAObject],
+    #         somacore.Scene[
+    #             Union[ImplGeometryDataFrame, ImplPointCloud], # _SpatialDF
+    #             ImplImageCollection,                          # _ImageColl
+    #             ImplSOMAObject,                               # _RootSO
+    #         ],
+    #     ):
+    #         ...
+
+    __slots__ = ()
+    soma_type: Final = "SOMAScene"  # type: ignore[misc]
+
+    img = _mixin.item[collection.Collection[_ImageColl]]()
+    """A collection of imagery of the spatial data in the scene
+
+    Each collection in this collection may contain either a single image or a
+    multi-resolution collection of images.
+
+    Lifecycle: experimental
+    """
+
+    obsl = _mixin.item[collection.Collection[_SpatialDF]]()
+    """A dataframe of the obs locations
+
+    This collection stores any spatial data in the scene that joins on the observables
+    in the parent ``Experiment``'s ``obs`` dataframe. The ``soma_joinid`` for
+    dataframes in this collection join on the ``obsid``.
+
+    Lifecycle: experimental
+    """
+
+    varl = _mixin.item[collection.Collection[collection.Collection[_SpatialDF]]]()
+    """A collection of collections of dataframes of the var locations.
+
+    This collection stores any spatial data in the scene that joins on the annoted
+    variables stored in the ``Measurement``'s ``var`` dataframes in the parent
+    ``Experiment``.
+
+    The top-level collection maps from measurement name to a collection of dataframes.
+    The ``soma_joinid`` of dataframes inside each of these collections join on the
+    ``varid`` of the respective ``Measuremetn``.
+
+    Lifecycle: experimental
+    """

--- a/python-spec/testing/test_collection.py
+++ b/python-spec/testing/test_collection.py
@@ -40,3 +40,5 @@ class EphemeralCollectionTest(unittest.TestCase):
         self.assertEqual("SOMAMeasurement", m.soma_type)
         exp = ephemeral.Experiment()
         self.assertEqual("SOMAExperiment", exp.soma_type)
+        scene = ephemeral.Scene()
+        self.assertEqual("SOMAScene", scene.soma_type)


### PR DESCRIPTION
This adds the `Scene` collection to the python-spec and the parent `spatial` group as a pre-defined type to the `Experiment` collection.