### PR TITLE
Use `Lifecycle: maturing` for query `obsm`/`varm`

### DIFF
--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -257,13 +257,13 @@ class ExperimentAxisQuery(Generic[_Exp]):
 
     def obsm(self, layer: str) -> data.SparseRead:
         """Returns an ``obsm`` layer as a sparse read.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._axism_inner(_Axis.OBS, layer)
 
     def varm(self, layer: str) -> data.SparseRead:
         """Returns a ``varm`` layer as a sparse read.
-        Lifecycle: experimental
+        Lifecycle: maturing
         """
         return self._axism_inner(_Axis.VAR, layer)
 


### PR DESCRIPTION
In prep for upcoming spatial-transcriptomics work, which will be tagged experimental.

See also https://github.com/single-cell-data/TileDB-SOMA/pull/2807