### PR TITLE
Drop unused categories in `ExperimentAxisQuery.to_anndata`

### DIFF
--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -277,6 +277,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         obsp_layers: Sequence[str] = (),
         varm_layers: Sequence[str] = (),
         varp_layers: Sequence[str] = (),
+        drop_levels: bool = False,
     ) -> anndata.AnnData:
         """
         Executes the query and return result as an ``AnnData`` in-memory object.
@@ -308,13 +309,14 @@ class ExperimentAxisQuery(Generic[_Exp]):
             varp_layers=varp_layers,
         ).to_anndata()
 
-        # Drop unused categories on axis dataframes
-        for name in ad.obs:
-            if pd.api.types.is_categorical_dtype(ad.obs[name]):
-                ad.obs[name] = ad.obs[name].cat.remove_unused_categories()
-        for name in ad.var:
-            if pd.api.types.is_categorical_dtype(ad.var[name]):
-                ad.var[name] = ad.var[name].cat.remove_unused_categories()
+        # Drop unused categories on axis dataframes if requested
+        if drop_levels:
+            for name in ad.obs:
+                if pd.api.types.is_categorical_dtype(ad.obs[name]):
+                    ad.obs[name] = ad.obs[name].cat.remove_unused_categories()
+            for name in ad.var:
+                if pd.api.types.is_categorical_dtype(ad.var[name]):
+                    ad.var[name] = ad.var[name].cat.remove_unused_categories()
 
         return ad
 

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -307,7 +307,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
             varm_layers=varm_layers,
             varp_layers=varp_layers,
         ).to_anndata()
-        
+
         # Drop unused categories on axis dataframes
         for name in ad.obs:
             if pd.api.types.is_categorical_dtype(ad.obs[name]):
@@ -315,7 +315,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         for name in ad.var:
             if pd.api.types.is_categorical_dtype(ad.var[name]):
                 ad.var[name] = ad.var[name].cat.remove_unused_categories()
-        
+
         return ad
 
     # Context management

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -298,7 +298,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
 
         Lifecycle: maturing
         """
-        return self._read(
+        ad = self._read(
             X_name,
             column_names=column_names or AxisColumnNames(obs=None, var=None),
             X_layers=X_layers,
@@ -307,6 +307,16 @@ class ExperimentAxisQuery(Generic[_Exp]):
             varm_layers=varm_layers,
             varp_layers=varp_layers,
         ).to_anndata()
+        
+        # Drop unused categories on axis dataframes
+        for name in ad.obs:
+            if pd.api.types.is_categorical_dtype(ad.obs[name]):
+                ad.obs[name] = ad.obs[name].cat.remove_unused_categories()
+        for name in ad.var:
+            if pd.api.types.is_categorical_dtype(ad.var[name]):
+                ad.var[name] = ad.var[name].cat.remove_unused_categories()
+        
+        return ad
 
     # Context management
 

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -296,6 +296,9 @@ class ExperimentAxisQuery(Generic[_Exp]):
                 Additional varm layers to read and return in the varm slot.
             varp_layers:
                 Additional varp layers to read and return in the varp slot.
+            drop_levels:
+                Indicate whether unused categories on axis frames should be
+                dropped. By default, False, the categories are not dropped.
 
         Lifecycle: maturing
         """

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -298,7 +298,8 @@ class ExperimentAxisQuery(Generic[_Exp]):
                 Additional varp layers to read and return in the varp slot.
             drop_levels:
                 Indicate whether unused categories on axis frames should be
-                dropped. By default, False, the categories are not dropped.
+                dropped. By default, False, the categories which are present in the SOMA Experiment
+                and not present in the query output are not dropped.
 
         Lifecycle: maturing
         """


### PR DESCRIPTION
**Issue:**
https://github.com/single-cell-data/TileDB-SOMA/issues/2765

**Changes:**
`ExperimentAxisQuery.to_anndata` iterates through each column and drops unused categories.

**Notes for Reviewer:**
This change was originally proposed in https://github.com/single-cell-data/TileDB-SOMA/pull/2811 but was suggested somacore was a more appropriate location for it.