### PR TITLE
Correct formatting for `to_anndata` doc string

### DIFF
--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -298,8 +298,9 @@ class ExperimentAxisQuery(Generic[_Exp]):
                 Additional varp layers to read and return in the varp slot.
             drop_levels:
                 Indicate whether unused categories on axis frames should be
-                dropped. By default, False, the categories which are present in the SOMA Experiment
-                and not present in the query output are not dropped.
+                dropped. By default, False, the categories which are present
+                in the SOMA Experimentand not present in the query output
+                are not dropped.
 
         Lifecycle: maturing
         """


### PR DESCRIPTION
I made a docstring correction to https://github.com/single-cell-data/SOMA/pull/204 and then merged immediately assuming that it would not affect CI, but it failed the formatting check.