### PR TITLE
Update pre-commit linters and new lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   # Start with the basic pre-commit hooks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -14,7 +14,7 @@ repos:
   # Then others in alphabetical order:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.5.5
     hooks:
       - id: ruff
 
@@ -23,7 +23,7 @@ repos:
     # the entire dependency list here we only install `attrs`. It will catch
     # a useful subset of errors but does not replace a full mypy run
     # (either locally or in CI).
-    rev: v1.5.1
+    rev: v1.11.1
     hooks:
       - id: mypy
         additional_dependencies: [attrs]
@@ -36,6 +36,6 @@ repos:
         # with `types_or` in the future.
 
   - repo: https://github.com/psf/black
-    rev: "23.9.1"
+    rev: "24.4.2"
     hooks:
       - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ tag_regex = '^python-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 
 [tool.ruff]
 lint.extend-select = ["I"]
+target-version = "py38"
 
 [tool.ruff.lint.isort]
 force-single-line = true
@@ -53,6 +54,7 @@ single-line-exclusions = ["typing", "typing_extensions"]
 check_untyped_defs = true
 enable_error_code = ["ignore-without-code"]
 warn_redundant_casts = true
+python_version = 3.8
 # We want to enable this but it won't work when running locally due to the
 # presence of _version.py (which invalidates the ignore, which causes an error).
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ urls = { repository = "https://github.com/single-cell-data/SOMA.git" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 
 [project.optional-dependencies]
-dev = ["black", "isort", "mypy~=1.0", "ruff"]
+dev = ["black", "isort", "mypy~=1.0", "ruff", "pandas-stubs"]
 
 [tool.setuptools]
 packages.find.where = ["python-spec/src"]
@@ -42,9 +42,9 @@ write_to = "python-spec/src/somacore/_version.py"
 tag_regex = '^python-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 
 [tool.ruff]
-extend-select = ["I"]
+lint.extend-select = ["I"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 known-first-party = ["somacore"]
 single-line-exclusions = ["typing", "typing_extensions"]

--- a/python-spec/src/somacore/_mixin.py
+++ b/python-spec/src/somacore/_mixin.py
@@ -54,12 +54,10 @@ class item(Generic[_T]):
             self.item_name = name
 
     @overload
-    def __get__(self, inst: None, owner: Type[_Coll]) -> "item[_T]":
-        ...
+    def __get__(self, inst: None, owner: Type[_Coll]) -> "item[_T]": ...
 
     @overload
-    def __get__(self, inst: _Coll, owner: Type[_Coll]) -> _T:
-        ...
+    def __get__(self, inst: _Coll, owner: Type[_Coll]) -> _T: ...
 
     def __get__(self, inst: Optional[_Coll], owner: Type[_Coll]) -> Union["item", _T]:
         del owner  # unused

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -62,8 +62,7 @@ class BaseCollection(  # type: ignore[misc]  # __eq__ false positive
         *,
         uri: Optional[str] = ...,
         platform_config: Optional[options.PlatformConfig] = ...,
-    ) -> "Collection":
-        ...
+    ) -> "Collection": ...
 
     @overload
     @abc.abstractmethod
@@ -74,8 +73,7 @@ class BaseCollection(  # type: ignore[misc]  # __eq__ false positive
         *,
         uri: Optional[str] = ...,
         platform_config: Optional[options.PlatformConfig] = ...,
-    ) -> _CT:
-        ...
+    ) -> _CT: ...
 
     @abc.abstractmethod
     def add_new_collection(

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -573,7 +573,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
             axis.getattr_from(self.indexer, pre="by_"),
         )
         idx = indexer(table["soma_dim_0"])
-        z = np.zeros(n_row * n_col, dtype=np.float32)
+        z: np.ndarray = np.zeros(n_row * n_col, dtype=np.float32)
         np.put(z, idx * n_col + table["soma_dim_1"], table["soma_data"])
         return z.reshape(n_row, n_col)
 

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -317,10 +317,10 @@ class ExperimentAxisQuery(Generic[_Exp]):
         # Drop unused categories on axis dataframes if requested
         if drop_levels:
             for name in ad.obs:
-                if pd.api.types.is_categorical_dtype(ad.obs[name]):
+                if isinstance(ad.obs[name], pd.CategoricalDtype):
                     ad.obs[name] = ad.obs[name].cat.remove_unused_categories()
             for name in ad.var:
-                if pd.api.types.is_categorical_dtype(ad.var[name]):
+                if isinstance(ad.obs[name], pd.CategoricalDtype):
                     ad.var[name] = ad.var[name].cat.remove_unused_categories()
 
         return ad
@@ -672,18 +672,17 @@ class _Axis(enum.Enum):
         return super().value
 
     @overload
-    def getattr_from(self, __source: "_HasObsVar[_T]") -> "_T":
-        ...
+    def getattr_from(self, __source: "_HasObsVar[_T]") -> "_T": ...
 
     @overload
     def getattr_from(
         self, __source: Any, *, pre: Literal[""], suf: Literal[""]
-    ) -> object:
-        ...
+    ) -> object: ...
 
     @overload
-    def getattr_from(self, __source: Any, *, pre: str = ..., suf: str = ...) -> object:
-        ...
+    def getattr_from(
+        self, __source: Any, *, pre: str = ..., suf: str = ...
+    ) -> object: ...
 
     def getattr_from(self, __source: Any, *, pre: str = "", suf: str = "") -> object:
         """Equivalent to ``something.<pre><obs/var><suf>``."""
@@ -820,16 +819,13 @@ class _Experimentish(Protocol):
     """The API we need from an Experiment."""
 
     @property
-    def ms(self) -> Mapping[str, measurement.Measurement]:
-        ...
+    def ms(self) -> Mapping[str, measurement.Measurement]: ...
 
     @property
-    def obs(self) -> data.DataFrame:
-        ...
+    def obs(self) -> data.DataFrame: ...
 
     @property
-    def context(self) -> Optional[base_types.ContextBase]:
-        ...
+    def context(self) -> Optional[base_types.ContextBase]: ...
 
 
 class _HasObsVar(Protocol[_T_co]):
@@ -839,9 +835,7 @@ class _HasObsVar(Protocol[_T_co]):
     """
 
     @property
-    def obs(self) -> _T_co:
-        ...
+    def obs(self) -> _T_co: ...
 
     @property
-    def var(self) -> _T_co:
-        ...
+    def var(self) -> _T_co: ...

--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -49,16 +49,13 @@ class Slice(Protocol[_T_co]):
     # invariant rather than covariant.
 
     @property
-    def start(self) -> Optional[_T_co]:
-        ...
+    def start(self) -> Optional[_T_co]: ...
 
     @property
-    def stop(self) -> Optional[_T_co]:
-        ...
+    def stop(self) -> Optional[_T_co]: ...
 
     @property
-    def step(self) -> Optional[_T_co]:
-        ...
+    def step(self) -> Optional[_T_co]: ...
 
     if sys.version_info < (3, 10) and not TYPE_CHECKING:
         # Python 3.9 and below have a bug where any Protocol with an @property


### PR DESCRIPTION
Update linter versions, set target Python version for linters to Python 3.8, and address new linter errors.

Lint fixes:
* Add pandas stub
* Remove call to deprecated `pd.api.types.is_categorical_dtype`
* Add type annotation for numpy array variable
* Update pyproject.toml ruff syntax
* Black format changes