### PR TITLE
Correct category dtype check in `ExperimentAxisQuery`

### DIFF
--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -317,10 +317,10 @@ class ExperimentAxisQuery(Generic[_Exp]):
         # Drop unused categories on axis dataframes if requested
         if drop_levels:
             for name in ad.obs:
-                if isinstance(ad.obs[name], pd.CategoricalDtype):
+                if ad.obs[name].dtype.name == "category":
                     ad.obs[name] = ad.obs[name].cat.remove_unused_categories()
             for name in ad.var:
-                if isinstance(ad.var[name], pd.CategoricalDtype):
+                if ad.var[name].dtype.name == "category":
                     ad.var[name] = ad.var[name].cat.remove_unused_categories()
 
         return ad


### PR DESCRIPTION
`ad.{obs,var}[name]` is always type `pd.Series`. We need to use `.dtype` to check the type of the column.

The original code used `pd.api.types.is_categorical_dtype` but that function is now deprecated.

---

```
(soma-3.11) vivian@mangonada:~/SOMA$ git log -1 --oneline
5ca6d91 (HEAD -> vn/correct-category-check, origin/vn/correct-category-check) Correct category dtype check in `ExperimentAxisQuery`

(soma-3.11) vivian@mangonada:~/TileDB-SOMA$ pip show somacore
Name: somacore
Version: 1.0.14.dev1+g402b2bc.d20240809
Summary: Python-language API specification and base utilities for implementation of the SOMA system.
Home-page:
Author:
Author-email:
License:
Location: /home/vivian/anaconda3/envs/soma-3.11/lib/python3.11/site-packages
Requires: anndata, attrs, numba, numpy, pandas, pyarrow, pyarrow-hotfix, scipy, typing-extensions
Required-by:

(soma-3.11) vivian@mangonada:~/TileDB-SOMA$ pytest apis/python/tests/ -k test_empty_categor
ical_query
=================================== test session starts ===================================
platform linux -- Python 3.11.0, pytest-8.0.1, pluggy-1.4.0
rootdir: /home/vivian/TileDB-SOMA/apis/python
plugins: cov-5.0.0, typeguard-4.2.1, hypothesis-6.98.9
collected 1766 items / 1765 deselected / 1 selected

apis/python/tests/test_experiment_query.py .                                        [100%]
```