### PR TITLE
Add full implementation of CoordinateSpace and CoordinateTransform

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -21,6 +21,7 @@ from .coordinates import Axis
 from .coordinates import CoordinateSpace
 from .coordinates import CoordinateTransform
 from .coordinates import IdentityTransform
+from .coordinates import ScaleTransform
 from .data import DataFrame
 from .data import DenseNDArray
 from .data import GeometryDataFrame
@@ -83,4 +84,5 @@ __all__ = (
     "CoordinateTransform",
     "AffineTransform",
     "IdentityTransform",
+    "ScaleTransform",
 )

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -16,9 +16,11 @@ import pyarrow_hotfix  # noqa: F401
 
 from .base import SOMAObject
 from .collection import Collection
+from .coordinates import AffineTransform
 from .coordinates import Axis
 from .coordinates import CoordinateSpace
 from .coordinates import CoordinateTransform
+from .coordinates import IdentityTransform
 from .data import DataFrame
 from .data import DenseNDArray
 from .data import GeometryDataFrame
@@ -79,4 +81,6 @@ __all__ = (
     "Axis",
     "CoordinateSpace",
     "CoordinateTransform",
+    "AffineTransform",
+    "IdentityTransform",
 )

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -1,9 +1,9 @@
 """Definitions of types related to coordinate systems."""
 
 import abc
-from collections.abc import Sequence
+import collections.abc
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -26,7 +26,7 @@ class Axis(metaclass=abc.ABCMeta):
     scale: Optional[np.float64] = None
 
 
-class CoordinateSpace(Sequence[Axis]):
+class CoordinateSpace(collections.abc.Sequence):
     """A coordinate system for spatial data."""
 
     def __init__(self, axes: Sequence[Axis]):

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -239,7 +239,7 @@ class ScaleTransform(AffineTransform):
             return ScaleTransform(
                 self.input_axes,
                 self.output_axes,
-                other.scale_factors * self.scale_factors,  # type: ignore[operator]
+                other.scale_factors * self.scale_factors,  # type: ignore[operator, union-attr]
             )
         if isinstance(other, CoordinateTransform):
             if self.output_axes != other.input_axes:

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -1,6 +1,7 @@
 """Definitions of types related to coordinate systems."""
 
 import abc
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -24,14 +25,39 @@ class Axis(metaclass=abc.ABCMeta):
     scale: Optional[np.float64] = None
 
 
-class CoordinateSpace(metaclass=abc.ABCMeta):
+class CoordinateSpace(Sequence[Axis]):
     """A coordinate system for spatial data."""
 
+    def __init__(self, axes: Sequence[Axis]):
+        """TODO: Add docstring"""
+        # TODO: Needs good, comprehensive error handling.
+        if len(tuple(axes)) == 0:
+            raise ValueError("Coordinate space must have at least one axis.")
+        self._axes = tuple(axes)
+
+    def __len__(self) -> int:
+        return len(self._axes)
+
+    def __getitem__(self, index: int) -> Axis:  # type: ignore[override]
+        return self._axes[index]
+
+    def __repr__(self) -> str:
+        output = f"<{type(self).__name__}\n"
+        for axis in self._axes:
+            output += f"  {axis},\n"
+        return output + ">"
+
     @property
-    @abc.abstractmethod
     def axes(self) -> Tuple[Axis, ...]:
-        """TODO: Add docstring for axes"""
-        raise NotImplementedError()
+        """TODO: Add docstring"""
+        return self._axes
+
+    @property
+    def axis_names(self) -> Tuple[str, ...]:
+        return tuple(axis.name for axis in self._axes)
+
+    def rank(self) -> int:
+        return len(self)
 
 
 class CoordinateTransform(metaclass=abc.ABCMeta):

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+from somacore import AffineTransform
+from somacore import CoordinateTransform
+from somacore import IdentityTransform
+
+
+def check_transform_is_equal(
+    actual: CoordinateTransform, desired: CoordinateTransform
+) -> None:
+    assert actual.input_axes == desired.input_axes
+    assert actual.output_axes == desired.output_axes
+    if isinstance(desired, IdentityTransform):
+        assert isinstance(actual, IdentityTransform)
+    elif isinstance(desired, AffineTransform):
+        assert isinstance(actual, AffineTransform)
+        np.testing.assert_array_equal(actual.augmented_matrix, desired.augmented_matrix)
+    else:
+        assert False
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                [[2, 2, 0], [0, 3, 1]],
+            ),
+            np.array([[2, 2, 0], [0, 3, 1], [0, 0, 1]], np.float64),
+        )
+    ],
+)
+def test_affine_augmented_matrix(input, expected):
+    result = input.augmented_matrix
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("transform_a", "transform_b", "expected"),
+    [
+        (
+            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
+            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
+            IdentityTransform(["x1", "y1"], ["x3", "y3"]),
+        ),
+        (
+            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
+            AffineTransform(
+                ["x2", "y2"],
+                ["x3", "y3"],
+                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
+            ),
+            AffineTransform(
+                ["x1", "y1"],
+                ["x3", "y3"],
+                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
+            ),
+        ),
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
+            ),
+            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
+            AffineTransform(
+                ["x1", "y1"],
+                ["x3", "y3"],
+                np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
+            ),
+        ),
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                np.array([[2.0, 0.0, 1.0], [0.0, 4.0, 1.0]], dtype=np.float64),
+            ),
+            AffineTransform(
+                ["x2", "y2"],
+                ["x3", "y3"],
+                np.array([[1.0, 1.0, -1.0], [0.0, 1.0, 2.0]], dtype=np.float64),
+            ),
+            AffineTransform(
+                ["x1", "y1"],
+                ["x3", "y3"],
+                np.array([[2.0, 2.0, -1.0], [0.0, 4.0, 9.0]], dtype=np.float64),
+            ),
+        ),
+    ],
+)
+def test_multiply_tranform(
+    transform_a,
+    transform_b,
+    expected: CoordinateTransform,
+):
+    result = transform_a * transform_b
+    check_transform_is_equal(result, expected)


### PR DESCRIPTION
This moves the implementation of the `Axis`, `CoordinateSpace`, and `CoordinateTransform` class from TileDB-SOMA to SOMA. It also adds a `ScaleTransform` class.