### PR TITLE
Replace somacore `ImageCollection` and `Image2DCollection` with `MultiscaleImage` 

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -32,8 +32,7 @@ from .data import SparseNDArray
 from .data import SparseRead
 from .data import SpatialDataFrame
 from .experiment import Experiment
-from .images import Image2DCollection
-from .images import ImageCollection
+from .images import MultiscaleImage
 from .measurement import Measurement
 from .options import BatchSize
 from .options import IOfN
@@ -66,9 +65,8 @@ __all__ = (
     "SparseRead",
     "Experiment",
     "Measurement",
+    "MultiscaleImage",
     "Scene",
-    "ImageCollection",
-    "Image2DCollection",
     "SpatialDataFrame",
     "PointCloud",
     "GeometryDataFrame",

--- a/python-spec/src/somacore/ephemeral/__init__.py
+++ b/python-spec/src/somacore/ephemeral/__init__.py
@@ -7,7 +7,6 @@ Collection.
 
 from .collections import Collection
 from .collections import Experiment
-from .collections import ImageCollection
 from .collections import Measurement
 from .collections import Scene
 
@@ -15,6 +14,5 @@ __all__ = (
     "Collection",
     "Experiment",
     "Measurement",
-    "ImageCollection",
     "Scene",
 )

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -4,11 +4,9 @@ from typing import (
     Iterator,
     NoReturn,
     Optional,
-    Sequence,
     TypeVar,
 )
 
-import pyarrow as pa
 from typing_extensions import Literal, Self
 
 from .. import base
@@ -134,7 +132,7 @@ _BasicAbstractMeasurement = measurement.Measurement[
 
 _BasicAbstractScene = scene.Scene[
     collection.Collection[data.SpatialDataFrame],
-    images.ImageCollection,
+    images.MultiscaleImage,
     base.SOMAObject,
 ]
 """The loosest possible constraint of the abstract Scene type."""
@@ -158,47 +156,6 @@ class Scene(  # type: ignore[misc]   # __eq__ false positive
     @property
     def coordinate_space(self) -> coordinates.CoordinateSpace:
         """Coordinate system for this scene."""
-        raise NotImplementedError()
-
-
-class ImageCollection(  # type: ignore[misc]   # __eq__ false positive
-    BaseCollection[base.SOMAObject],
-    images.ImageCollection[data.DenseNDArray, base.SOMAObject],
-):
-    """An in-memory Collection with Image semantics."""
-
-    __slots__ = ()
-
-    def add_new_level(
-        self,
-        key: str,
-        *,
-        uri: Optional[str] = None,
-        type: pa.DataType,
-        shape: Sequence[int],
-    ) -> data.DenseNDArray:
-        raise NotImplementedError()
-
-    @property
-    def axis_order(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def level_count(self) -> int:
-        raise NotImplementedError()
-
-    def level_properties(self, level: int) -> images.ImageCollection.LevelProperties:
-        raise NotImplementedError()
-
-    def read_level(
-        self,
-        level: int,
-        coords: options.DenseNDCoords = (),
-        *,
-        transform: Optional[coordinates.CoordinateTransform] = None,
-        result_order: options.ResultOrderStr = options.ResultOrder.AUTO,
-        platform_config: Optional[options.PlatformConfig] = None,
-    ) -> pa.Tensor:
         raise NotImplementedError()
 
 

--- a/python-spec/src/somacore/images.py
+++ b/python-spec/src/somacore/images.py
@@ -214,7 +214,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     @property
     @abc.abstractmethod
-    def reference_level_shape(self) -> Optional[Tuple[int, ...]]:
+    def reference_level_properties(self) -> LevelProperties:
         """The reference shape for this multiscale image pyramid.
 
         In most cases this should correspond to the shape of the image at level 0. If

--- a/python-spec/src/somacore/images.py
+++ b/python-spec/src/somacore/images.py
@@ -28,6 +28,42 @@ _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 _RO_AUTO = options.ResultOrder.AUTO
 
 
+class ImageProperties(Protocol):
+    """Class requirements for level properties of images.
+
+    Lifecycle: experimental
+    """
+
+    @property
+    def name(self) -> str:
+        """The key for the image.
+
+        Lifecycle: experimental
+        """
+
+    @property
+    def image_type(self) -> str:
+        """A string describing the axis order of the image data.
+
+        A valid image type is a permuation of 'YX', 'YXC', 'YXZ', or 'YXZC'. The
+        letters have the following meanings:
+
+        * 'X' - image width
+        * 'Y' - image height
+        * 'Z' - image depth (for three dimensional images)
+        * 'C' - channels/bands
+
+        Lifecycle: experimental
+        """
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """Size of each axis of the image.
+
+        Lifecycle: experimental
+        """
+
+
 class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     base.SOMAObject,
     Generic[_DenseND, _RootSO],
@@ -52,26 +88,6 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     soma_type: Final = "SOMAMultiscaleImage"  # type: ignore[misc]
     __slots__ = ()
-
-    class LevelProperties(Protocol):
-        """Class requirements for level properties of images.
-
-        Lifecycle: experimental
-        """
-
-        @property
-        def name(self) -> str:
-            """The key for the image.
-
-            Lifecycle: experimental
-            """
-
-        @property
-        def shape(self) -> Tuple[int, ...]:
-            """Number of pixels for each dimension of the image.
-
-            Lifecycle: experimental
-            """
 
     @classmethod
     @abc.abstractmethod
@@ -104,7 +120,10 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     @property
     @abc.abstractmethod
     def axis_names(self) -> Tuple[str, ...]:
-        # TODO: Add docstring
+        """The name of the image axes.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -113,7 +132,6 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         key: str,
         *,
         uri: Optional[str] = None,
-        type: pa.DataType,  # TODO: Remove this option
         shape: Sequence[int],
     ) -> data.DenseNDArray:
         """Add a new level in the multi-scale image.
@@ -186,12 +204,18 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     @property
     @abc.abstractmethod
     def level_count(self) -> int:
-        """The number of image levels stored in the MultiscaleImage."""
+        """The number of image levels stored in the MultiscaleImage.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def level_properties(self, level: Union[int, str]) -> LevelProperties:
-        """The properties of an image at the specified level."""
+    def level_properties(self, level: Union[int, str]) -> ImageProperties:
+        """The properties of an image at the specified level.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -214,7 +238,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     @property
     @abc.abstractmethod
-    def reference_level_properties(self) -> LevelProperties:
+    def reference_level_properties(self) -> ImageProperties:
         """The reference shape for this multiscale image pyramid.
 
         In most cases this should correspond to the shape of the image at level 0. If

--- a/python-spec/src/somacore/images.py
+++ b/python-spec/src/somacore/images.py
@@ -79,9 +79,10 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         cls,
         uri: str,
         *,
-        axis_order: str,
-        full_resolution_shape: Optional[Tuple[int, ...]] = None,
-        coordinate_space: Optional[coordinates.CoordinateSpace] = None,
+        type: pa.DataType,
+        image_type: str = "CYX",
+        reference_level_shape: Sequence[int],
+        axis_names: Sequence[str] = ("c", "x", "y"),
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:
@@ -89,12 +90,21 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
         Args:
             uri: The URI where the collection will be created.
-            axis_order
+            axis_names: The names of the axes of the image.
+            reference_level_shape: # TODO
+            image_type: The order of the image axes # TODO
+
         Returns:
             The newly created collection, opened for writing.
 
         Lifecycle: experimental
         """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def axis_names(self) -> Tuple[str, ...]:
+        # TODO: Add docstring
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -103,7 +113,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         key: str,
         *,
         uri: Optional[str] = None,
-        type: pa.DataType,
+        type: pa.DataType,  # TODO: Remove this option
         shape: Sequence[int],
     ) -> data.DenseNDArray:
         """Add a new level in the multi-scale image.
@@ -111,14 +121,6 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         Parameters are as in :meth:`data.DenseNDArray.create`. The provided shape will
         be used to compute the scale between images and must correspond to the image
         size for the entire image.
-
-        Lifecycle: experimental
-        """
-        raise NotImplementedError()
-
-    @property
-    def axis_order(self) -> str:
-        """The order of the axes in the stored images.
 
         Lifecycle: experimental
         """
@@ -142,20 +144,19 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         raise NotImplementedError()
 
-    @property
     @abc.abstractmethod
-    def reference_shape(self) -> Optional[Tuple[int, ...]]:
-        """The reference shape for this multiscale image pyramid.
+    def get_transformation_from_level(
+        self, level: Union[int, str]
+    ) -> coordinates.ScaleTransform:
+        """Returns the transformation from the MultiscaleImage base coordinate
+        system to the requested level.
 
-        In most cases this should correspond to the shape of the image at level 0.
+        If ``reference_shape`` is set, this will be the scale transformation from the
+        ``reference_shape`` to the requested level. If ``reference_shape`` is not set,
+        the transformation will be to from the level 0 image to the reequence level.
 
         Lifecycle: experimental
         """
-        raise NotImplementedError()
-
-    @reference_shape.setter
-    @abc.abstractmethod
-    def reference_shape(self, value: Tuple[int, ...]) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -168,6 +169,15 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         If ``reference_shape`` is set, this will be the scale transformation from the
         ``reference_shape`` to the requested level. If ``reference_shape`` is not set,
         the transformation will be to from the level 0 image to the reequence level.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def image_type(self) -> str:
+        """The order of the axes as stored in the data model.
 
         Lifecycle: experimental
         """
@@ -195,4 +205,22 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> pa.Tensor:
         """TODO: Add read_image_level documentation"""
+        raise NotImplementedError()
+
+    @property
+    def reference_level(self) -> Optional[int]:
+        """TODO: Add docstring"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def reference_level_shape(self) -> Optional[Tuple[int, ...]]:
+        """The reference shape for this multiscale image pyramid.
+
+        In most cases this should correspond to the shape of the image at level 0. If
+        ``data_axis_order`` is not ``None``, the shape will be in the same order as the
+        data as stored on disk.
+
+        Lifecycle: experimental
+        """
         raise NotImplementedError()

--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -12,7 +12,7 @@ from . import coordinates
 from . import data
 from . import images
 
-_ImageColl = TypeVar("_ImageColl", bound=images.ImageCollection)
+_MSImage = TypeVar("_MSImage", bound=images.MultiscaleImage)
 """A particular implementation of a collection of spatial arrays."""
 _SpatialDFColl = TypeVar(
     "_SpatialDFColl", bound=collection.Collection[data.SpatialDataFrame]
@@ -23,7 +23,7 @@ _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 
 class Scene(
     collection.BaseCollection[_RootSO],
-    Generic[_SpatialDFColl, _ImageColl, _RootSO],
+    Generic[_SpatialDFColl, _MSImage, _RootSO],
 ):
     """TODO: Add documentation for scene
 
@@ -41,7 +41,7 @@ class Scene(
     #             ImplCollection[
     #                 Union[ImplGeometryDataFrame, ImplPointCloud]]
     #             ], # _SpatialDFColl
-    #             ImplImageCollection,                          # _ImageColl
+    #             ImplMultiscaleImage,                          # _MSImage
     #             ImplSOMAObject,                               # _RootSO
     #         ],
     #     ):
@@ -50,20 +50,8 @@ class Scene(
     __slots__ = ()
     soma_type: Final = "SOMAScene"  # type: ignore[misc]
 
-    img = _mixin.item[_ImageColl]()
-    """A collection of imagery backing the spatial data
-
-    This collection can contain a combination of sparse and dense arrays that
-    contain images or image masks. The specifics of how to best store and manage
-    this data internal to the group needs to be explored in more detail. Ideally,
-    we would support the following:
-
-    * Single backing image
-    * Multi-resolution images
-    * Multiple image tiles that create a larger image (may be touching images or with
-      gaps)
-    * Image masks on top of any of the above
-    """
+    img = _mixin.item[collection.Collection[_MSImage]]()
+    """A collection of multi-scale imagery backing the spatial data."""
 
     obsl = _mixin.item[_SpatialDFColl]()
     """A dataframe of the obs locations

--- a/python-spec/testing/test_collection.py
+++ b/python-spec/testing/test_collection.py
@@ -42,5 +42,3 @@ class EphemeralCollectionTest(unittest.TestCase):
         self.assertEqual("SOMAExperiment", exp.soma_type)
         scene = ephemeral.Scene()
         self.assertEqual("SOMAScene", scene.soma_type)
-        img = ephemeral.ImageCollection()
-        self.assertEqual("SOMAImageCollection", img.soma_type)


### PR DESCRIPTION
This PR cleans up the multiscale image pyramid class. It includes the following:

- [x] Merge `ImageCollection` and `Image2DCollection` into a single class 
- [x] Rename new class to `MultiscaleImage`
- [x] Remove `Collection` methods from `MultiscaleImage` (e.g. ability to add subcollections, sparse arrays, etc.)
- [x] Add property for coordinate space
- [x] Add property to get transformations to/from image levels
- [x] Refine create method
- [x] General clean-up (refine param/method names, add docstrings, etc.)