### PR TITLE
Update API for spatial reads and fix CoordinateTransforms

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -38,9 +38,11 @@ from .query import AxisQuery
 from .query import ExperimentAxisQuery
 from .scene import Scene
 from .spatialdata import GeometryDataFrame
+from .spatialdata import ImageProperties
 from .spatialdata import MultiscaleImage
 from .spatialdata import PointCloud
 from .spatialdata import SpatialDataFrame
+from .spatialdata import SpatialReadIter
 from .types import ContextBase
 
 try:
@@ -66,10 +68,12 @@ __all__ = (
     "Experiment",
     "Measurement",
     "MultiscaleImage",
+    "ImageProperties",
     "Scene",
     "SpatialDataFrame",
     "PointCloud",
     "GeometryDataFrame",
+    "SpatialReadIter",
     "BatchSize",
     "IOfN",
     "ResultOrder",

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -42,7 +42,7 @@ from .spatialdata import ImageProperties
 from .spatialdata import MultiscaleImage
 from .spatialdata import PointCloud
 from .spatialdata import SpatialDataFrame
-from .spatialdata import SpatialReadIter
+from .spatialdata import SpatialRead
 from .types import ContextBase
 
 try:
@@ -73,7 +73,7 @@ __all__ = (
     "SpatialDataFrame",
     "PointCloud",
     "GeometryDataFrame",
-    "SpatialReadIter",
+    "SpatialRead",
     "BatchSize",
     "IOfN",
     "ResultOrder",

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -201,10 +201,11 @@ class AffineTransform(CoordinateTransform):
 
     def inverse_transform(self) -> CoordinateTransform:
         inv_a = np.linalg.inv(self._matrix[:-1, :-1])
+        b2 = inv_a @ self._matrix[:-1, -1].reshape((self.output_rank, 1))
         inv_augmented: npt.NDArray[np.float64] = np.vstack(
             (
-                np.hstack((inv_a, inv_a @ self._matrix[-1, :-1])),
-                np.hstack((np.zeros(self.input_rank), np.array([1]))),
+                np.hstack((inv_a, b2)),
+                np.hstack((np.zeros(self.output_rank), np.array([1]))),
             )
         )
         return AffineTransform(self.output_axes, self.input_axes, inv_augmented)

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -152,14 +152,14 @@ class AffineTransform(CoordinateTransform):
                 other * self.augmented_matrix,  # type: ignore[operator]
             )
         if isinstance(other, CoordinateTransform):
-            if self.output_axes != other.input_axes:
+            if self.input_axes != other.output_axes:
                 raise ValueError("Axis mismatch between transformations.")
             if isinstance(other, IdentityTransform):
-                return AffineTransform(self.input_axes, other.output_axes, self._matrix)
+                return AffineTransform(other.input_axes, self.output_axes, self._matrix)
             if isinstance(other, AffineTransform):
                 return AffineTransform(
-                    self.input_axes,
-                    other.output_axes,
+                    other.input_axes,
+                    self.output_axes,
                     self.augmented_matrix @ other.augmented_matrix,
                 )
         if isinstance(other, np.ndarray):
@@ -174,16 +174,16 @@ class AffineTransform(CoordinateTransform):
         if np.isscalar(other):
             return self.__mul__(other)
         if isinstance(other, CoordinateTransform):
-            if other.output_axes != self.input_axes:
+            if other.input_axes != self.output_axes:
                 raise ValueError("Axis mismatch between transformations.")
             if isinstance(other, IdentityTransform):
                 return AffineTransform(
-                    other.input_axes, self.output_axes, self.augmented_matrix
+                    self.input_axes, other.output_axes, self.augmented_matrix
                 )
             if isinstance(other, AffineTransform):
                 return AffineTransform(
-                    other.input_axes,
-                    self.output_axes,
+                    self.input_axes,
+                    other.output_axes,
                     other.augmented_matrix @ self.augmented_matrix,
                 )
         if isinstance(other, np.ndarray):
@@ -247,18 +247,18 @@ class ScaleTransform(AffineTransform):
                 other.scale_factors * self.scale_factors,  # type: ignore[operator, union-attr]
             )
         if isinstance(other, CoordinateTransform):
-            if self.output_axes != other.input_axes:
+            if self.input_axes != other.output_axes:
                 raise ValueError("Axis mismatch between transformations.")
             if isinstance(other, ScaleTransform):  # Includes IdentityTransform
                 return ScaleTransform(
-                    self.input_axes,
-                    other.output_axes,
+                    other.input_axes,
+                    self.output_axes,
                     self.scale_factors * other.scale_factors,
                 )
             if isinstance(other, AffineTransform):
                 return AffineTransform(
-                    self.input_axes,
-                    other.output_axes,
+                    other.input_axes,
+                    self.output_axes,
                     self.augmented_matrix @ other.augmented_matrix,
                 )
         if isinstance(other, np.ndarray):
@@ -273,22 +273,22 @@ class ScaleTransform(AffineTransform):
         if np.isscalar(other):
             return self.__mul__(other)
         if isinstance(other, CoordinateTransform):
-            if other.output_axes != self.input_axes:
+            if other.input_axes != self.output_axes:
                 raise ValueError("Axis mismatch between transformations.")
             if isinstance(other, IdentityTransform):
                 return ScaleTransform(
-                    other.input_axes, self.output_axes, self._scale_factors
+                    self.input_axes, other.output_axes, self._scale_factors
                 )
             if isinstance(other, ScaleTransform):
                 return ScaleTransform(
-                    other.input_axes,
-                    self.output_axes,
+                    self.input_axes,
+                    other.output_axes,
                     self._scale_factors * other._scale_factors,
                 )
             if isinstance(other, AffineTransform):
                 return AffineTransform(
-                    other.input_axes,
-                    self.output_axes,
+                    self.input_axes,
+                    other.output_axes,
                     other.augmented_matrix @ self.augmented_matrix,
                 )
         if isinstance(other, np.ndarray):
@@ -348,9 +348,9 @@ class IdentityTransform(ScaleTransform):
             return ScaleTransform(self.input_axes, self.output_axes, other)
         if isinstance(other, CoordinateTransform):
             if isinstance(other, IdentityTransform):
-                if self.output_axes != other.input_axes:
+                if other.output_axes != self.input_axes:
                     raise ValueError("Axis mismatch between transformations.")
-                return IdentityTransform(self.input_axes, other.output_axes)
+                return IdentityTransform(other.input_axes, self.output_axes)
             return other.__rmul__(self)
         if isinstance(other, np.ndarray):
             raise NotImplementedError(
@@ -367,7 +367,7 @@ class IdentityTransform(ScaleTransform):
             if isinstance(other, IdentityTransform):
                 if other.output_axes != self.input_axes:
                     raise ValueError("Axis mismatch between transformations.")
-                return IdentityTransform(other.input_axes, self.output_axes)
+                return IdentityTransform(self.input_axes, other.output_axes)
             return other.__mul__(self)
         if isinstance(other, np.ndarray):
             raise NotImplementedError(

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -201,7 +201,7 @@ class AffineTransform(CoordinateTransform):
 
     def inverse_transform(self) -> CoordinateTransform:
         inv_a = np.linalg.inv(self._matrix[:-1, :-1])
-        b2 = inv_a @ self._matrix[:-1, -1].reshape((self.output_rank, 1))
+        b2 = -inv_a @ self._matrix[:-1, -1].reshape((self.output_rank, 1))
         inv_augmented: npt.NDArray[np.float64] = np.vstack(
             (
                 np.hstack((inv_a, b2)),

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -184,7 +184,8 @@ SparseNDCoord = Union[
 SparseNDCoords = Sequence[SparseNDCoord]
 """A sequence of coordinate ranges for reading sparse ndarrays."""
 
-"""A single coordinate range for one dimension of a sparse dataframe."""
+SpatialDFCoords = Union[SparseNDCoords, shapely.GeometryType]
+"""A sequence of coordinate ranges or a shape for reading spatial dataframes."""
 
-GeometryDFCoords = Sequence[Union[SparseNDCoord, shapely.GeometryType]]
-"""A sequence of coordinate ranges for reading dense dataframes."""
+ImageCoords = Union[DenseNDCoords, shapely.GeometryType]
+"""A sequemce of coordinate ranges or a shape for reading multiscale images."""

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -184,8 +184,8 @@ SparseNDCoord = Union[
 SparseNDCoords = Sequence[SparseNDCoord]
 """A sequence of coordinate ranges for reading sparse ndarrays."""
 
-SpatialDFCoords = Union[SparseNDCoords, shapely.GeometryType]
-"""A sequence of coordinate ranges or a shape for reading spatial dataframes."""
 
-ImageCoords = Union[DenseNDCoords, shapely.GeometryType]
-"""A sequemce of coordinate ranges or a shape for reading multiscale images."""
+SpatialRegion = Union[
+    npt.NDArray[np.integer], npt.NDArray[np.floating], shapely.GeometryType
+]
+"""A spatial region used for reading spatial dataframes and multiscale images."""

--- a/python-spec/src/somacore/options.py
+++ b/python-spec/src/somacore/options.py
@@ -185,7 +185,5 @@ SparseNDCoords = Sequence[SparseNDCoord]
 """A sequence of coordinate ranges for reading sparse ndarrays."""
 
 
-SpatialRegion = Union[
-    npt.NDArray[np.integer], npt.NDArray[np.floating], shapely.GeometryType
-]
+SpatialRegion = Union[Sequence[int], Sequence[float], shapely.GeometryType]
 """A spatial region used for reading spatial dataframes and multiscale images."""

--- a/python-spec/src/somacore/spatialdata.py
+++ b/python-spec/src/somacore/spatialdata.py
@@ -571,12 +571,17 @@ _T = TypeVar("_T")
 # Sparse reads are returned as an iterable structure:
 
 
-class SpatialReadIter(data.ReadIter[_T], metaclass=abc.ABCMeta):
+class SpatialReadIter(Generic[_T], metaclass=abc.ABCMeta):
 
     __slots__ = ()
 
     # __iter__ is already implemented as `return self` in Iterator.
     # SOMA implementations must implement __next__.
+
+    @property
+    @abc.abstractmethod
+    def data(self) -> data.ReadIter[_T]:
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod

--- a/python-spec/src/somacore/spatialdata.py
+++ b/python-spec/src/somacore/spatialdata.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Generic,
+    Mapping,
     MutableMapping,
     Optional,
     Sequence,
@@ -84,9 +85,10 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def spatial_read(
         self,
-        region: options.SpatialDFCoords = (),
+        region: Optional[options.SpatialRegion] = None,
         column_names: Optional[Sequence[str]] = None,
         *,
+        extra_coords: Optional[Mapping[str, options.SparseDFCoord]] = None,
         transform: Optional[coordinates.CoordinateTransform] = None,
         region_coord_space: Optional[coordinates.CoordinateSpace] = None,
         batch_size: options.BatchSize = options.BatchSize(),
@@ -105,6 +107,8 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
                 Defaults to ``()``, meaning no constraint -- all IDs.
             column_names: the named columns to read and return.
                 Defaults to ``None``, meaning no constraint -- all column names.
+            extra_coords: a name to coordinate mapping non-spatial index columns.
+                Defaults to selecting entire region for non-spatial coordinates.
             transform: coordinate transform to apply to results.
                 Defaults to ``None``, meaning an identity transform.
             region_coord_space: the coordinate space of the region being read.
@@ -405,8 +409,9 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     def read_level(
         self,
         level: Union[int, str],
-        region: options.ImageCoords = (),
+        region: options.SpatialRegion = (),
         *,
+        channel_coords: options.DenseCoord = None,
         transform: Optional[coordinates.CoordinateTransform] = None,
         region_coord_space: Optional[coordinates.CoordinateSpace] = None,
         apply_mask: bool = False,

--- a/python-spec/src/somacore/spatialdata.py
+++ b/python-spec/src/somacore/spatialdata.py
@@ -88,6 +88,7 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         column_names: Optional[Sequence[str]] = None,
         *,
         transform: Optional[coordinates.CoordinateTransform] = None,
+        region_coord_space: Optional[coordinates.CoordinateSpace] = None,
         batch_size: options.BatchSize = options.BatchSize(),
         partitions: Optional[options.ReadPartitions] = None,
         result_order: options.ResultOrderStr = _RO_AUTO,
@@ -106,6 +107,8 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
                 Defaults to ``None``, meaning no constraint -- all column names.
             transform: coordinate transform to apply to results.
                 Defaults to ``None``, meaning an identity transform.
+            region_coord_space: the coordinate space of the region being read.
+                Defaults to ``None``, coordinate space will be infer from transform.
             batch_size: The size of batched reads.
                 Defaults to `unbatched`.
             partitions: If present, specifies that this is part of
@@ -405,6 +408,8 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         region: options.ImageCoords = (),
         *,
         transform: Optional[coordinates.CoordinateTransform] = None,
+        region_coord_space: Optional[coordinates.CoordinateSpace] = None,
+        apply_mask: bool = False,
         result_order: options.ResultOrderStr = _RO_AUTO,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> "SpatialRead[pa.Tensor]":

--- a/python-spec/src/somacore/spatialdata.py
+++ b/python-spec/src/somacore/spatialdata.py
@@ -83,7 +83,7 @@ class SpatialDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def spatial_read(
+    def read_region(
         self,
         region: Optional[options.SpatialRegion] = None,
         column_names: Optional[Sequence[str]] = None,

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -99,26 +99,26 @@ def test_inverse_transform(input, expected):
     ("transform_a", "transform_b", "expected"),
     [
         (
-            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             IdentityTransform(["x2", "y2"], ["x3", "y3"]),
+            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             IdentityTransform(["x1", "y1"], ["x3", "y3"]),
         ),
         (
-            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             ScaleTransform(
                 ["x2", "y2"], ["x3", "y3"], np.array([1.5, 3.0], dtype=np.float64)
             ),
+            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             ScaleTransform(
                 ["x1", "y1"], ["x3", "y3"], np.array([1.5, 3.0], dtype=np.float64)
             ),
         ),
         (
-            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             AffineTransform(
                 ["x2", "y2"],
                 ["x3", "y3"],
                 np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
             ),
+            IdentityTransform(["x1", "y1"], ["x2", "y2"]),
             AffineTransform(
                 ["x1", "y1"],
                 ["x3", "y3"],
@@ -126,21 +126,21 @@ def test_inverse_transform(input, expected):
             ),
         ),
         (
+            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
             ScaleTransform(
                 ["x1", "y1"], ["x2", "y2"], np.array([1.5, 3.0], dtype=np.float64)
             ),
-            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
             ScaleTransform(
                 ["x1", "y1"], ["x3", "y3"], np.array([1.5, 3.0], dtype=np.float64)
             ),
         ),
         (
+            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
             AffineTransform(
                 ["x1", "y1"],
                 ["x2", "y2"],
                 np.array([[1.5, 3.0, 0.0], [-1.5, 3.0, 1.0]], dtype=np.float64),
             ),
-            IdentityTransform(["x2", "y2"], ["x3", "y3"]),
             AffineTransform(
                 ["x1", "y1"],
                 ["x3", "y3"],
@@ -148,19 +148,19 @@ def test_inverse_transform(input, expected):
             ),
         ),
         (
-            ScaleTransform(["x1", "y1"], ["x2", "y2"], 1.5),
             ScaleTransform(["x2", "y2"], ["x3", "y3"], [1.0, -1.0]),
+            ScaleTransform(["x1", "y1"], ["x2", "y2"], 1.5),
             ScaleTransform(["x1", "y1"], ["x3", "y3"], [1.5, -1.5]),
         ),
         (
             AffineTransform(
-                ["x1", "y1"],
                 ["x2", "y2"],
+                ["x3", "y3"],
                 np.array([[2.0, 0.0, 1.0], [0.0, 4.0, 1.0]], dtype=np.float64),
             ),
             AffineTransform(
+                ["x1", "y1"],
                 ["x2", "y2"],
-                ["x3", "y3"],
                 np.array([[1.0, 1.0, -1.0], [0.0, 1.0, 2.0]], dtype=np.float64),
             ),
             AffineTransform(

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -47,6 +47,28 @@ def test_affine_augmented_matrix(input, expected):
 
 
 @pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                [[1, 0, 0], [0, 1, 0]],
+            ),
+            AffineTransform(
+                ["x2", "y2"],
+                ["x1", "y1"],
+                [[1, 0, 0], [0, 1, 0]],
+            ),
+        )
+    ],
+)
+def test_inverse_transform(input, expected):
+    result = input.inverse_transform()
+    check_transform_is_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     ("transform_a", "transform_b", "expected"),
     [
         (

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -60,12 +60,39 @@ def test_affine_augmented_matrix(input, expected):
                 ["x1", "y1"],
                 [[1, 0, 0], [0, 1, 0]],
             ),
-        )
+        ),
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                [[1, 0, 5], [0, 1, 10]],
+            ),
+            AffineTransform(
+                ["x2", "y2"],
+                ["x1", "y1"],
+                [[1, 0, -5], [0, 1, -10]],
+            ),
+        ),
+        (
+            AffineTransform(
+                ["x1", "y1"],
+                ["x2", "y2"],
+                [[2, 0, -5], [0, 4, 5]],
+            ),
+            AffineTransform(
+                ["x2", "y2"],
+                ["x1", "y1"],
+                [[0.5, 0, 2.5], [0, 0.25, -1.25]],
+            ),
+        ),
     ],
 )
 def test_inverse_transform(input, expected):
     result = input.inverse_transform()
     check_transform_is_equal(result, expected)
+    result_matrix = input.augmented_matrix @ result.augmented_matrix
+    expected_matrix = np.identity(result.input_rank + 1, dtype=np.float64)
+    np.testing.assert_allclose(result_matrix, expected_matrix)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Update API for `MultiscaleImage.read_level` method
* Add `SpatialDataFrame.read_region` method 
* Fix composition (`__mul__`, `__rmul__`) in the coordinate transform classes
* Add methods to return inverse of the coordinate transform classes
* Remove apply methods from the coordinate transform classes