### PR TITLE
Use correct shape for obsm/varm layers in anndata export

### DIFF
--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -592,13 +592,13 @@ class ExperimentAxisQuery(Generic[_Exp]):
         axis: "_Axis",
         layer: str,
     ) -> np.ndarray:
-        table = self._axism_inner(axis, layer).tables().concat()
-        shape = tuple(
-            pa.compute.count_distinct(f).as_py()
-            for f in table.select(["soma_dim_0", "soma_dim_1"]).itercolumns()
-        )
+        axism = axis.getitem_from(self._ms, suf="m")
+        table = axism[layer].read().tables().concat()
 
-        return self._convert_to_ndarray(axis, table, shape[0], shape[1])
+        n_row = len(axis.getattr_from(self._joinids))
+        n_col = pa.compute.count_distinct(table["soma_dim_1"]).as_py()
+
+        return self._convert_to_ndarray(axis, table, n_row, n_col)
 
     @property
     def _obs_df(self) -> data.DataFrame:

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -596,7 +596,7 @@ class ExperimentAxisQuery(Generic[_Exp]):
         table = axism[layer].read().tables().concat()
 
         n_row = len(axis.getattr_from(self._joinids))
-        n_col = pa.compute.count_distinct(table["soma_dim_1"]).as_py()
+        n_col = len(table["soma_dim_1"].unique())
 
         return self._convert_to_ndarray(axis, table, n_row, n_col)
 

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -592,13 +592,13 @@ class ExperimentAxisQuery(Generic[_Exp]):
         axis: "_Axis",
         layer: str,
     ) -> np.ndarray:
-        axism = axis.getitem_from(self._ms, suf="m")
-
-        _, n_col = axism[layer].shape
-        n_row = len(axis.getattr_from(self._joinids))
-
         table = self._axism_inner(axis, layer).tables().concat()
-        return self._convert_to_ndarray(axis, table, n_row, n_col)
+        shape = tuple(
+            pa.compute.count_distinct(f).as_py()
+            for f in table.select(["soma_dim_0", "soma_dim_1"]).itercolumns()
+        )
+
+        return self._convert_to_ndarray(axis, table, shape[0], shape[1])
 
     @property
     def _obs_df(self) -> data.DataFrame:


### PR DESCRIPTION
## Overview

This addresses a bug in the `ExperimentAxisQuery` anndata exporter that is specific to `obsm`/`varm` arrays.

## Details

Currently, the number of columns needed for the resulting numpy array is taken from the `SparseNDArray`'s shape property, which provides the maximum capacity of the underlying TileDB array, rather than the occupied capacity. This results in the exporter allocating a far larger numpy `ndarray` than necessary when obsm/varm layers are included in the output.

This issue is specific to `obsm`/`varm` arrays because, unlike `X`/`obsp`/`varp`, and as described [here](https://github.com/single-cell-data/TileDB-SOMA/blob/753d9f7d3ff31237fd2907bc6da17a0c6f1ba070/apis/python/src/tiledbsoma/io/outgest.py#L384-L400), their second dimension doesn't map to the `obs` or `var` axis and can include an arbitrary number of columns.

## Solution

With this PR the correct number of columns needed for the resulting numpy array is computed using the number of unique values present in the COO-formatted arrow table's `"soma_dim_1"` column, which is already in-memory and doesn't require any additional TileDB queries.

This solution is a temporary workaround, as `SparseNDArray.shape`'s behavior will change in an upcoming release of TileDB-SOMA (see [here](https://github.com/single-cell-data/TileDB-SOMA/issues/2407) for status).

**Note: The TileDB-SOMA `SparseNDArray` class does provide a `used_shape` property that returns the occupied capacity of the underlying TileDB array that could be used, however, this is specific to the TileDB implementation and is not part of the SOMA API specification.**
