### PR TITLE
Fix type hint for CoordinateSpace `axis`

### DIFF
--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -35,7 +35,7 @@ class CoordinateSpace(collections.abc.Sequence[Axis]):
     Lifecycle: experimental
     """
 
-    axes: Tuple[Axis] = attrs.field(converter=tuple)
+    axes: Tuple[Axis, ...] = attrs.field(converter=tuple)
 
     @axes.validator
     def _validate(self, _, axes: Tuple[Axis, ...]) -> None:

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 
 from somacore import AffineTransform
+from somacore import Axis
+from somacore import CoordinateSpace
 from somacore import CoordinateTransform
 from somacore import IdentityTransform
 from somacore import ScaleTransform
@@ -26,6 +28,15 @@ def check_transform_is_equal(
         np.testing.assert_array_equal(actual.augmented_matrix, desired.augmented_matrix)
     else:
         assert False
+
+
+def test_coordinate_space():
+    coord_space = CoordinateSpace(
+        (Axis("x", unit="nanometer"), Axis("y", unit="nanometer"))  # type: ignore[arg-type]
+    )
+    assert len(coord_space) == 2
+    assert coord_space.axis_names == ("x", "y")
+    assert coord_space[0] == Axis("x", unit="nanometer")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PR #227 forgot to add an ellipses with the tuple.