### PR TITLE
Small fixes to new spatial classes

### DIFF
--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -154,9 +154,9 @@ class Scene(
         *,
         uri: str,
         type: pa.DataType,
-        image_type: str = "CYX",  # TODO: Replace this arg after PR #219 is merged
         reference_level_shape: Sequence[int],
         axis_names: Sequence[str] = ("c", "x", "y"),
+        axis_types: Sequence[str] = ("channel", "height", "width"),
     ) -> _MultiscaleImage:
         """Adds a ``MultiscaleImage`` to the scene and sets a coordinate transform
         between the scene and the dataframe.

--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -224,7 +224,7 @@ class PointCloud(base.SOMAObject, metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def coordinate_space(self) -> Optional[coordinates.CoordinateSpace]:
+    def coordinate_space(self) -> coordinates.CoordinateSpace:
         """Coordinate space for this point cloud.
 
         Lifecycle: experimental
@@ -470,7 +470,7 @@ class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def coordinate_space(self) -> Optional[coordinates.CoordinateSpace]:
+    def coordinate_space(self) -> coordinates.CoordinateSpace:
         """Coordinate space for this geometry dataframe.
 
         Lifecycle: experimental
@@ -639,7 +639,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     @property
     @abc.abstractmethod
-    def coordinate_space(self) -> Optional[coordinates.CoordinateSpace]:
+    def coordinate_space(self) -> coordinates.CoordinateSpace:
         """Coordinate space for this multiscale image.
 
         Lifecycle: experimental


### PR DESCRIPTION
* Make the `coordinate_space` property not optional in the `PointCloud`, `GeometryDataFrame`, and `MultiscaleImage` classes.
* Fix bad parameter definition for the `Scene.add_multiscale_image` method.