### PR TITLE
Sync `domain` argument between `Collection.add_new_dataframe` and `DataFrame.create`

### DIFF
--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -1,5 +1,14 @@
 import abc
-from typing import Any, MutableMapping, Optional, Sequence, Type, TypeVar, overload
+from typing import (
+    Any,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    overload,
+)
 
 import pyarrow as pa
 from typing_extensions import Final, Self
@@ -145,6 +154,7 @@ class BaseCollection(  # type: ignore[misc]  # __eq__ false positive
         uri: Optional[str] = None,
         schema: pa.Schema,
         index_column_names: Sequence[str] = (options.SOMA_JOINID,),
+        domain: Optional[Sequence[Optional[Tuple[Any, Any]]]] = None,
         platform_config: Optional[options.PlatformConfig] = None,
     ) -> data.DataFrame:
         """Creates a new DataFrame as a child of this collection.


### PR DESCRIPTION
**Issue and/or context:** As tracked on issue https://github.com/single-cell-data/TileDB-SOMA/issues/2407 / [[sc-51048]](https://app.shortcut.com/tiledb-inc/story/51048).

Note that the intended Python and R API changes are all agreed on and finalized as described in #2407.

**Changes:**

The `Collection.add_new_dataframe` is syntactic sugar on `DataFrame.create`. The latter takes an optional `domain` argument, so the former should as well.

This is not only generally important for https://github.com/single-cell-data/TileDB-SOMA/issues/2407; it is specifically for the cellxgene census builder which uses `add_new_dataframe` exclusively.

**Notes for Reviewer:**