### PR TITLE
Update the MultiscaleImage API

### DIFF
--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -39,7 +39,6 @@ from .query import AxisQuery
 from .query import ExperimentAxisQuery
 from .scene import Scene
 from .spatial import GeometryDataFrame
-from .spatial import ImageProperties
 from .spatial import MultiscaleImage
 from .spatial import PointCloudDataFrame
 from .spatial import SpatialRead

--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -589,6 +589,37 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def set(
+        self,
+        key: str,
+        value: data.DenseNDArray,
+        *,
+        use_relative_uri: Optional[bool] = None,
+    ):
+        """Sets a new level in the multi-scale image to be an existing SOMA
+        :class:`data.DenseNDArray`.
+
+        Args:
+            key: The string key to set.
+            value: The SOMA object to insert into the collection.
+            use_relative_uri: Determines whether to store the collection
+                entry with a relative URI (provided the storage engine
+                supports it).
+                If ``None`` (the default), will automatically determine whether
+                to use an absolute or relative URI based on their relative
+                location.
+                If ``True``, will always use a relative URI. If the new child
+                does not share a relative URI base, or use of relative URIs
+                is not possible at all, the collection should raise an error.
+                If ``False``, will always use an absolute URI.
+
+        Returns: ``self``, to enable method chaining.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
     # Data operations
 
     @abc.abstractmethod

--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -258,6 +258,12 @@ class PointCloudDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+    @property
+    @abc.abstractmethod
+    def data_axis_order(self) -> Tuple[str, ...]:
+        """Returns the data axis order of the image data."""
+        raise NotImplementedError()
+
 
 class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     """A specialized SOMA object for storing complex geometries with spatial indexing.
@@ -537,9 +543,9 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             "y",
         ),
         data_axis_order: Optional[Sequence[str]] = None,
+        has_channel_axis: bool = True,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
-        has_channel_axis: bool = True,
     ) -> Self:
         """Creates a new MultiscaleImage with one initial level.
 
@@ -578,7 +584,7 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         *,
         uri: Optional[str] = None,
         shape: Sequence[int],
-    ) -> data.DenseNDArray:
+    ) -> _DenseND:
         """Add a new level in the multi-scale image.
 
         Parameters are as in :meth:`data.DenseNDArray.create`. The provided shape will
@@ -593,10 +599,10 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
     def set(
         self,
         key: str,
-        value: data.DenseNDArray,
+        value: _DenseND,
         *,
         use_relative_uri: Optional[bool] = None,
-    ):
+    ) -> Self:
         """Sets a new level in the multi-scale image to be an existing SOMA
         :class:`data.DenseNDArray`.
 
@@ -690,6 +696,15 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
         """
         raise NotImplementedError()
 
+    @property
+    @abc.abstractmethod
+    def data_axis_order(self) -> Tuple[str, ...]:
+        """The order of the axes for the images.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
     @abc.abstractmethod
     def get_transform_from_level(
         self, level: Union[int, str]
@@ -713,6 +728,15 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     @property
     @abc.abstractmethod
+    def has_channel_axis(self) -> bool:
+        """Returns if the images have an explicit channel axis.
+
+        Lifecycle: experimental.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
     def level_count(self) -> int:
         """The number of image levels stored in the MultiscaleImage.
 
@@ -722,7 +746,16 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
 
     @abc.abstractmethod
     def level_shape(self, level: Union[int, str]) -> Tuple[int, ...]:
-        """The properties of an image at the specified level.
+        """The shape of the image at the specified level.
+
+        Lifecycle: experimental
+        """
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def nchannels(self) -> int:
+        """The number of channels.
 
         Lifecycle: experimental
         """

--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -258,12 +258,6 @@ class PointCloudDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
-    @property
-    @abc.abstractmethod
-    def data_axis_order(self) -> Tuple[str, ...]:
-        """Returns the data axis order of the image data."""
-        raise NotImplementedError()
-
 
 class GeometryDataFrame(base.SOMAObject, metaclass=abc.ABCMeta):
     """A specialized SOMA object for storing complex geometries with spatial indexing.


### PR DESCRIPTION
This PR addresses feedback from PR #219 regarding the `MultiscaleImage` API. It includes the following changes:

* Directly take the `CoordinateSpace` as a creation parameter.
* Remove confusing `image_type` property/creation parameter. Use `data_axis_order` instead which uses the axis names the user provided.
* Create the first resolution level when creating the `MultiscaleImage`.
* Require the `add_new_level` to only add images smaller than the base (level=0) image.
* Add a `set` method for adding images that exist outside of SOMA.
* Add a property to check the number of channels in the image.
* Remove `ImageProperties` class.