### PR TITLE
rm py3.9 `__subclasscheck__` workaround

### DIFF
--- a/python-spec/src/somacore/types.py
+++ b/python-spec/src/somacore/types.py
@@ -5,11 +5,8 @@ but are intended to be used by SOMA implementations for annotations and
 their own internal type-checking purposes.
 """
 
-import sys
 from concurrent import futures
 from typing import (
-    TYPE_CHECKING,
-    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -84,13 +81,6 @@ class Slice(Protocol[_T_co]):
 
     @property
     def step(self) -> Optional[_T_co]: ...
-
-    if sys.version_info < (3, 10) and not TYPE_CHECKING:
-        # Python 3.9 and below have a bug where any Protocol with a @property
-        # was always regarded as runtime-checkable.
-        @classmethod
-        def __subclasscheck__(cls, __subclass: type) -> NoReturn:
-            raise TypeError("Slice is not a runtime-checkable protocol")
 
 
 def is_slice_of(__obj: object, __typ: Type[_T]) -> TypeGuard[Slice[_T]]:


### PR DESCRIPTION
This code dates to Feb '23, doesn't seem to be necessary for tests/CI (including Typeguard and mypy) to pass, and seems to be causing issues in TileDB-SOMA CI (e.g. https://github.com/single-cell-data/TileDB-SOMA/issues/3246).

[Here's](https://github.com/ryan-williams/tiledb-scratch/actions/runs/11560662489) a sweep of:
- Python: { 3.9.10, 3.9.19 3.12.7 }
- SOMA: { main, rw/slc (this branch) }
- Typeguard: { 4.2.1, 4.3.0, 4.4.0 }
- Single test case: [`test_dataframe_index_columns.py::test_types_no_errors[soma_joinid-py-slice-index_column_names4-domain4-coords4-expecteds4]`](https://github.com/single-cell-data/TileDB-SOMA/blob/24a74384964c1f7a62938dacb3a644f7488bba6f/apis/python/tests/test_dataframe_index_columns.py#L94-L103) (started failing on Python 3.9, ca. [typeguard#496] / 4.4.0)

![Screenshot 2024-10-28 at 2 57 50 PM](https://github.com/user-attachments/assets/91259b7a-f9b1-419e-9e38-f50f19c4713c)

Notes:
- **Typeguard 4.2.1:** everything passes. Typeguard added more checks and fixes in 4.3.0 and 4.4.0…
- **Typeguard 4.3.0:** everything fails, errors refer to `__orig_bases__`.
  - There was [discussion](https://github.com/single-cell-data/SOMA/pull/222/files#r1763786646) of this on [#222], ultimately [typeguard#496] was the fix, which landed in 4.4.0.
- **Typeguard 4.4.0:** Python 3.9 fails on `main`, everything passes on this branch.

I've been unable to find a situation where the `__subclasscheck__` block here is necessary; my best guess (and from discussing with @jp-dark) is that it was relevant to older Typeguard versions (TileDB-SOMA would have been [on 2.x](https://pypi.org/project/typeguard/#history) when this code was added, in Feb '23). I've locally tested Python versions 3.9.{4,7,10,11,13,19}, they all seem to have the same behavior (failure with Typeguard 4.4.0 and this code present, OK without this code, OK on 4.2.1 with and without this code).

[Here's](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/11562091272/job/32182513902?pr=3250) TileDB-SOMA CI passing when pointed at this branch (https://github.com/single-cell-data/TileDB-SOMA/pull/3250).

[#222]: https://github.com/single-cell-data/SOMA/pull/222
[typeguard#496]: https://github.com/agronholm/typeguard/pull/496