### PR TITLE
`_fast_csr` type fix, docstr/pre-commit tweaks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tag_regex = '^python-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 [tool.ruff]
 lint.extend-select = ["I"]
 target-version = "py39"
+fix = true
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -113,13 +113,14 @@ class SOMAObject(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     soma_type: ClassVar[LiteralString]
-    """A string describing the SOMA type of this object. This is constant."""
-    # This uses ClassVar since you can't do abstract class properties.
-    # This is the equivalent, just without abc-based automatic verification.
-    #
-    # Overrides are marked Final with an ignore[misc] because mypy by default
-    # wants this to be mutable, and doesn't like overriding the mutable member
-    # with a Final member.
+    """A string describing the SOMA type of this object. This is constant.
+
+    This uses ClassVar since you can't do abstract class properties.
+    This is the equivalent, just without abc-based automatic verification.
+    Overrides are marked Final with an ignore[misc] because mypy by default
+    wants this to be mutable, and doesn't like overriding the mutable member
+    with a Final member.
+    """
 
     # Context management
 

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -15,7 +15,7 @@ _DF = TypeVar("_DF", bound=data.DataFrame)
 _MeasColl = TypeVar("_MeasColl", bound=collection.Collection[measurement.Measurement])
 """An implementation of a collection of Measurements."""
 _SceneColl = TypeVar("_SceneColl", bound=collection.Collection[scene.Scene])
-"""An implemenation of a collection of spatial data."""
+"""An implementation of a collection of spatial data."""
 _RootSO = TypeVar("_RootSO", bound=base.SOMAObject)
 """The root SOMA object type of the implementation."""
 

--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -82,8 +82,8 @@ class _CSRAccumulator:
 
     def __init__(
         self,
-        obs_joinids: npt.NDArray[np.int64],
-        var_joinids: npt.NDArray[np.int64],
+        obs_joinids: pa.Array,
+        var_joinids: pa.Array,
         pool: futures.Executor,
         index_factory: types.IndexFactory,
     ):

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -414,7 +414,6 @@ class ExperimentAxisQuery(Generic[_Exp]):
     ) -> "_AxisQueryResult":
         """Reads the entire query result in memory.
 
-
         This is a low-level routine intended to be used by loaders for other
         in-core formats, such as AnnData, which can be created from the
         resulting objects.

--- a/python-spec/src/somacore/query/types.py
+++ b/python-spec/src/somacore/query/types.py
@@ -1,10 +1,13 @@
 """Common types used across SOMA query modules."""
 
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import numpy as np
 import numpy.typing as npt
+import pyarrow as pa
 from typing_extensions import Protocol
+
+_Array = Union[npt.NDArray[np.int64], pa.Array]
 
 
 class IndexLike(Protocol):
@@ -16,11 +19,11 @@ class IndexLike(Protocol):
     not as a full specification of the types and behavior of ``get_indexer``.
     """
 
-    def get_indexer(self, target: npt.NDArray[np.int64]) -> Any:
+    def get_indexer(self, target: _Array) -> Any:
         """Something compatible with Pandas' Index.get_indexer method."""
 
 
-IndexFactory = Callable[[npt.NDArray[np.int64]], "IndexLike"]
+IndexFactory = Callable[[_Array], "IndexLike"]
 """Function that builds an index over the given NDArray.
 
 This interface is implemented by the callable ``pandas.Index``.


### PR DESCRIPTION
`_CSRAccumulator` [declares][accumulator args] `{obs,var}_joinids` args of type `npt.NDArray[np.int64]`, but was [passed][accumulator call] `pa.Array`s.

[accumulator args]: https://github.com/single-cell-data/SOMA/blob/python-v1.0.23/python-spec/src/somacore/query/_fast_csr.py#L85-L86
[accumulator call]: https://github.com/single-cell-data/SOMA/blob/python-v1.0.23/python-spec/src/somacore/query/_fast_csr.py#L28-L30