### PR TITLE
lint: rm `force-single-line` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ target-version = "py39"
 fix = true
 
 [tool.ruff.lint.isort]
-force-single-line = true
 known-first-party = ["somacore"]
-single-line-exclusions = ["typing", "typing_extensions"]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/python-spec/src/somacore/__init__.py
+++ b/python-spec/src/somacore/__init__.py
@@ -16,32 +16,27 @@ import pyarrow_hotfix  # noqa: F401
 
 from .base import SOMAObject
 from .collection import Collection
-from .coordinates import AffineTransform
-from .coordinates import Axis
-from .coordinates import CoordinateSpace
-from .coordinates import CoordinateTransform
-from .coordinates import IdentityTransform
-from .coordinates import ScaleTransform
-from .coordinates import UniformScaleTransform
-from .data import DataFrame
-from .data import DenseNDArray
-from .data import NDArray
-from .data import ReadIter
-from .data import SparseNDArray
-from .data import SparseRead
+from .coordinates import (
+    AffineTransform,
+    Axis,
+    CoordinateSpace,
+    CoordinateTransform,
+    IdentityTransform,
+    ScaleTransform,
+    UniformScaleTransform,
+)
+from .data import DataFrame, DenseNDArray, NDArray, ReadIter, SparseNDArray, SparseRead
 from .experiment import Experiment
 from .measurement import Measurement
-from .options import BatchSize
-from .options import IOfN
-from .options import ResultOrder
-from .query import AxisColumnNames
-from .query import AxisQuery
-from .query import ExperimentAxisQuery
+from .options import BatchSize, IOfN, ResultOrder
+from .query import AxisColumnNames, AxisQuery, ExperimentAxisQuery
 from .scene import Scene
-from .spatial import GeometryDataFrame
-from .spatial import MultiscaleImage
-from .spatial import PointCloudDataFrame
-from .spatial import SpatialRead
+from .spatial import (
+    GeometryDataFrame,
+    MultiscaleImage,
+    PointCloudDataFrame,
+    SpatialRead,
+)
 from .types import ContextBase
 
 try:

--- a/python-spec/src/somacore/base.py
+++ b/python-spec/src/somacore/base.py
@@ -9,8 +9,7 @@ from typing import Any, ClassVar, MutableMapping, Optional
 
 from typing_extensions import LiteralString, Self
 
-from . import options
-from . import types
+from . import options, types
 
 
 class SOMAObject(metaclass=abc.ABCMeta):

--- a/python-spec/src/somacore/collection.py
+++ b/python-spec/src/somacore/collection.py
@@ -13,9 +13,7 @@ from typing import (
 import pyarrow as pa
 from typing_extensions import Final, Self
 
-from . import base
-from . import data
-from . import options
+from . import base, data, options
 
 _Elem = TypeVar("_Elem", bound=base.SOMAObject)
 """Element Type for a SOMA collection."""

--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -10,8 +10,7 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import Self
 
-from .types import str_or_seq_length
-from .types import to_string_tuple
+from .types import str_or_seq_length, to_string_tuple
 
 
 @attrs.define(frozen=True)

--- a/python-spec/src/somacore/data.py
+++ b/python-spec/src/somacore/data.py
@@ -21,8 +21,7 @@ from typing import (
 import pyarrow as pa
 from typing_extensions import Final, Literal, Self
 
-from . import base
-from . import options
+from . import base, options
 
 _RO_AUTO = options.ResultOrder.AUTO
 

--- a/python-spec/src/somacore/ephemeral/__init__.py
+++ b/python-spec/src/somacore/ephemeral/__init__.py
@@ -5,10 +5,7 @@ ad-hoc analysis of multiple datasets without having to create a stored
 Collection.
 """
 
-from .collections import Collection
-from .collections import Experiment
-from .collections import Measurement
-from .collections import Scene
+from .collections import Collection, Experiment, Measurement, Scene
 
 __all__ = (
     "Collection",

--- a/python-spec/src/somacore/ephemeral/collections.py
+++ b/python-spec/src/somacore/ephemeral/collections.py
@@ -9,15 +9,17 @@ from typing import (
 
 from typing_extensions import Literal, Self
 
-from .. import base
-from .. import collection
-from .. import coordinates
-from .. import data
-from .. import experiment
-from .. import measurement
-from .. import options
-from .. import scene
-from .. import spatial
+from .. import (
+    base,
+    collection,
+    coordinates,
+    data,
+    experiment,
+    measurement,
+    options,
+    scene,
+    spatial,
+)
 
 _Elem = TypeVar("_Elem", bound=base.SOMAObject)
 

--- a/python-spec/src/somacore/experiment.py
+++ b/python-spec/src/somacore/experiment.py
@@ -2,13 +2,7 @@ from typing import Generic, Optional, TypeVar
 
 from typing_extensions import Final, Self
 
-from . import _mixin
-from . import base
-from . import collection
-from . import data
-from . import measurement
-from . import query
-from . import scene
+from . import _mixin, base, collection, data, measurement, query, scene
 
 _DF = TypeVar("_DF", bound=data.DataFrame)
 """An implementation of a DataFrame."""

--- a/python-spec/src/somacore/measurement.py
+++ b/python-spec/src/somacore/measurement.py
@@ -4,10 +4,7 @@ from typing import Generic, TypeVar
 
 from typing_extensions import Final
 
-from . import _mixin
-from . import base
-from . import collection
-from . import data
+from . import _mixin, base, collection, data
 
 _DF = TypeVar("_DF", bound=data.DataFrame)
 """A particular implementation of DataFrame."""

--- a/python-spec/src/somacore/query/__init__.py
+++ b/python-spec/src/somacore/query/__init__.py
@@ -1,5 +1,4 @@
-from . import axis
-from . import query
+from . import axis, query
 
 ExperimentAxisQuery = query.ExperimentAxisQuery
 AxisColumnNames = query.AxisColumnNames

--- a/python-spec/src/somacore/query/_fast_csr.py
+++ b/python-spec/src/somacore/query/_fast_csr.py
@@ -10,8 +10,7 @@ import pyarrow as pa
 from scipy import sparse
 
 from .. import data as scd
-from . import _eager_iter
-from . import types
+from . import _eager_iter, types
 
 
 def read_csr(

--- a/python-spec/src/somacore/query/axis.py
+++ b/python-spec/src/somacore/query/axis.py
@@ -4,8 +4,7 @@ import attrs
 import numpy as np
 import pyarrow as pa
 
-from .. import options
-from .. import types
+from .. import options, types
 
 
 def _canonicalize_coords(

--- a/python-spec/src/somacore/query/query.py
+++ b/python-spec/src/somacore/query/query.py
@@ -25,13 +25,9 @@ import pyarrow.compute as pacomp
 from scipy import sparse
 from typing_extensions import Literal, Protocol, Self, TypedDict
 
-from .. import data
-from .. import measurement
-from .. import options
+from .. import data, measurement, options
 from .. import types as base_types
-from . import _fast_csr
-from . import axis
-from . import types
+from . import _fast_csr, axis, types
 
 _RO_AUTO = options.ResultOrder.AUTO
 

--- a/python-spec/src/somacore/scene.py
+++ b/python-spec/src/somacore/scene.py
@@ -5,11 +5,7 @@ from typing import Generic, Optional, Sequence, TypeVar, Union
 
 from typing_extensions import Final
 
-from . import _mixin
-from . import base
-from . import collection
-from . import coordinates
-from . import spatial
+from . import _mixin, base, collection, coordinates, spatial
 
 _MultiscaleImage = TypeVar("_MultiscaleImage", bound=spatial.MultiscaleImage)
 """A particular implementation of a multiscale image."""

--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -16,10 +16,7 @@ from typing import (
 import pyarrow as pa
 from typing_extensions import Final, Self
 
-from . import base
-from . import coordinates
-from . import data
-from . import options
+from . import base, coordinates, data, options
 
 _DenseND = TypeVar("_DenseND", bound=data.DenseNDArray)
 """A particular implementation of a collection of DenseNDArrays."""

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pytest
 
-from somacore import AffineTransform
-from somacore import Axis
-from somacore import CoordinateSpace
-from somacore import CoordinateTransform
-from somacore import IdentityTransform
-from somacore import ScaleTransform
-from somacore import UniformScaleTransform
+from somacore import (
+    AffineTransform,
+    Axis,
+    CoordinateSpace,
+    CoordinateTransform,
+    IdentityTransform,
+    ScaleTransform,
+    UniformScaleTransform,
+)
 
 
 def check_transform_is_equal(

--- a/python-spec/testing/test_mixin.py
+++ b/python-spec/testing/test_mixin.py
@@ -1,7 +1,6 @@
 import unittest
 
-from somacore import _mixin
-from somacore import ephemeral
+from somacore import _mixin, ephemeral
 
 
 class TestItem(unittest.TestCase):


### PR DESCRIPTION
The default lint config here yields more concise `import` blocks, and is more common IME (and used in TileDB-SOMA).

Not sure if there's a strong preference for the existing config, proposing this for discussion.