### PR TITLE
Remove unnecessary `has_channel_axis` create param

### DIFF
--- a/python-spec/src/somacore/spatial.py
+++ b/python-spec/src/somacore/spatial.py
@@ -537,7 +537,6 @@ class MultiscaleImage(  # type: ignore[misc]  # __eq__ false positive
             "y",
         ),
         data_axis_order: Optional[Sequence[str]] = None,
-        has_channel_axis: bool = True,
         platform_config: Optional[options.PlatformConfig] = None,
         context: Optional[Any] = None,
     ) -> Self:


### PR DESCRIPTION
This removes the redundant parameter `has_channel_axis` from the `MultiscaleScale.create` class method. The existence and location of a channel axis is already specified by the `data_axis_order` parameter.