### PR TITLE
Prevent `Axis.name` from staring with "soma_"

### DIFF
--- a/python-spec/src/somacore/coordinates.py
+++ b/python-spec/src/somacore/coordinates.py
@@ -23,10 +23,15 @@ class Axis:
     Lifecycle: experimental
     """
 
-    name: str
+    name: str = attrs.field()
     """Name of the axis."""
     unit: str | None = None
     """Optional string name for the units of the axis."""
+
+    @name.validator
+    def check(self, attribute, value):
+        if value.startswith("soma_"):
+            raise ValueError(f"Invalid axis name '{value}'. Cannot start with 'soma_'.")
 
 
 @attrs.define(frozen=True)

--- a/python-spec/testing/test_coordinates.py
+++ b/python-spec/testing/test_coordinates.py
@@ -30,6 +30,11 @@ def check_transform_is_equal(
         assert False
 
 
+def test_invalid_axis_name():
+    with pytest.raises(ValueError):
+        Axis("soma_axis")
+
+
 def test_coordinate_space():
     coord_space = CoordinateSpace(
         (Axis("x", unit="nanometer"), Axis("y", unit="nanometer"))  # type: ignore[arg-type]


### PR DESCRIPTION
The Axis name should never start with "soma_".