### PR TITLE
Use mdformat for markdown format/lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   # Start with the basic pre-commit hooks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -14,7 +14,7 @@ repos:
   # Then others in alphabetical order:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.11.9
     hooks:
       - id: ruff
 
@@ -23,19 +23,17 @@ repos:
     # the entire dependency list here we only install `attrs`. It will catch
     # a useful subset of errors but does not replace a full mypy run
     # (either locally or in CI).
-    rev: v1.11.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         additional_dependencies: [attrs]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
-    hooks:
-      - id: prettier
-        # For now we let this act on all files; if need be we can restrict it
-        # with `types_or` in the future.
-
   - repo: https://github.com/psf/black
-    rev: "24.4.2"
+    rev: "25.1.0"
     hooks:
       - id: black
+
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22  # Use the ref you want to point at
+    hooks:
+    - id: mdformat

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This has resulted in a need for scalable solutions to accommodate data sizes tha
 To address these emerging needs in the single cell ecosystem, the Chan Zuckerberg Initiative in partnership with TileDB is:
 
 1. Driving the development of SOMA.
-2. Providing its first implementation, [TileDB-SOMA](https://github.com/single-cell-data/TileDB-SOMA) which utilizes the [TileDB Embedded](https://github.com/TileDB-Inc/TileDB) engine.
-3. Adopting TileDB-SOMA at [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) to build its [Census](https://github.com/chanzuckerberg/cellxgene-census/) which provides efficient access and querying to a corpus containing nearly 50 million cells, compiled from 700+ datasets.
+1. Providing its first implementation, [TileDB-SOMA](https://github.com/single-cell-data/TileDB-SOMA) which utilizes the [TileDB Embedded](https://github.com/TileDB-Inc/TileDB) engine.
+1. Adopting TileDB-SOMA at [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) to build its [Census](https://github.com/chanzuckerberg/cellxgene-census/) which provides efficient access and querying to a corpus containing nearly 50 million cells, compiled from 700+ datasets.
 
 The `SOMA` specification and its `TileDB-SOMA` implementation provide the following capabilities for single-cell data:
 

--- a/abstract_specification.md
+++ b/abstract_specification.md
@@ -230,7 +230,7 @@ In addition to the `soma_joinid`, every `SOMAGeometryDataFrame` must contain a c
 names of other columns in the table. The `soma_geometry` must be an index column, but the user may also specify other additional columns as
 index columns. Multiple items with the same geometry may be stored in the `SOMAGeometryDataFrame`.
 
-SOMADataFrame`is the zero or null value of the respective column data type (e.g.,`Arrow.float32`defaults to 0.0,`Arrow.string`to`""`, etc).
+SOMADataFrame`is the zero or null value of the respective column data type (e.g.,`Arrow.float32`defaults to 0.0,`Arrow.string`to`""\`, etc).
 
 ### SOMADenseNDArray
 
@@ -243,7 +243,7 @@ All dimensions must have a positive, non-zero length, and there must be 1 or mor
 
 The default "fill" value for `SOMADenseNDArray` is the zero or null value of the array type (e.g., `Arrow.float32` defaults to 0.0).
 
-> ℹ️ **Note**: on TileDB this is an dense array with `N` `int64` dimensions of domain [0, maxInt64), and a single attribute.
+> ℹ️ **Note**: on TileDB this is an dense array with `N` `int64` dimensions of domain \[0, maxInt64), and a single attribute.
 
 ### SOMASparseNDArray
 
@@ -282,7 +282,7 @@ The `SOMAExperiment`, `SOMAMeasurement`, and `SOMAScene` types comprise [foundat
 - `SOMAMeasurement`: for all observables, a common set of annotated variables (defined by a `SOMADataFrame`) for which values (e.g., measurements, calculations) are stored in `SOMADenseNDArray` and `SOMASparseNDArray`.
 - `SOMAScene`: images and spatially indexed data stored on a fixed coordinate system that relate back to the observables and measurements.
 
-In other words, every `SOMAMeasurement` has a distinct set of variables (features), and inherits common observables from its parent `SOMAExperiment`. The `obs` and `var` dataframes define the axis annotations, and their respective `soma_joinid` values are the indices for all matrixes stored in the `SOMAMeasurement`. Each `SOMAScene` stores images and spatial dataframes that join on the `obs` and var` dataframes.
+In other words, every `SOMAMeasurement` has a distinct set of variables (features), and inherits common observables from its parent `SOMAExperiment`. The `obs` and `var` dataframes define the axis annotations, and their respective `soma_joinid` values are the indices for all matrixes stored in the `SOMAMeasurement`. Each `SOMAScene` stores images and spatial dataframes that join on the `obs` and var\` dataframes.
 
 <figure>
     <img src="images/SOMAExperiment.png" alt="SOMAExperiment">
@@ -305,32 +305,32 @@ The shape of each axis (`obs` and `var`) are defined by their respective datafra
 
 The pre-defined fields of a `SOMAExperiment` object are:
 
-| Field name             | Field type                                | Field description                                                                                                                                                                                                                           |
+| Field name | Field type | Field description |
 | ---------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `obs`                  | `SOMADataFrame`                           | Primary annotations on the _observation_ axis. The contents of the `soma_joinid` pseudo-column define the _observation_ index domain, also known as `obsid`. All observations for the `SOMAExperiment` _must_ be defined in this dataframe. |
-| `ms`                   | `SOMACollection[string, SOMAMeasurement]` | A collection of named measurements.                                                                                                                                                                                                         |
-| `spatial`              | `SOMACollection[string, SOMAScene]`       | A collection of named scenes.                                                                                                                                                                                                               |
-| `obs_spatial_presence` | `SOMADataFrame`                           | Join table that stores if a particular _observation_ is stored in a given `SOMAScene`. This dataframe is optional and may be omitted even in a `SOMAExperiment` with multiple `SOMAScene` items.                                            |
+| `obs` | `SOMADataFrame` | Primary annotations on the _observation_ axis. The contents of the `soma_joinid` pseudo-column define the _observation_ index domain, also known as `obsid`. All observations for the `SOMAExperiment` _must_ be defined in this dataframe. |
+| `ms` | `SOMACollection[string, SOMAMeasurement]` | A collection of named measurements. |
+| `spatial` | `SOMACollection[string, SOMAScene]` | A collection of named scenes. |
+| `obs_spatial_presence` | `SOMADataFrame` | Join table that stores if a particular _observation_ is stored in a given `SOMAScene`. This dataframe is optional and may be omitted even in a `SOMAExperiment` with multiple `SOMAScene` items. |
 
 The `SOMAMeasurement` is a sub-element of a `SOMAExperiment`, and is otherwise a specialized `SOMACollection` with pre-defined fields:
 
-| Field name             | Field type                                                    | Field description                                                                                                                                                                                                                                                                                  |
+| Field name | Field type | Field description |
 | ---------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `var`                  | `SOMADataFrame`                                               | Primary annotations on the _variable_ axis, for variables in this measurement (i.e., annotates columns of `X`). The contents of the `soma_joinid` pseudo-column define the _variable_ index domain, also known as `varid`. All variables for this measurement _must_ be defined in this dataframe. |
-| `X`                    | `SOMACollection[string, SOMASparseNDArray\|SOMADenseNDArray]` | A collection of matrices, each containing measured feature values. Each matrix is indexed by `[obsid, varid]`. Both sparse and dense 2D arrays are supported in `X`.                                                                                                                               |
-| `obsm`                 | `SOMACollection[string, SOMASparse\|SOMADenseNDArray]`        | A collection of dense matrices containing annotations of each _obs_ row. Has the same shape as `obs`, and is indexed with `obsid`.                                                                                                                                                                 |
-| `obsp`                 | `SOMACollection[string, SOMASparseNDArray]`                   | A collection of sparse matrices containing pairwise annotations of each _obs_ row. Indexed with `[obsid_1, obsid_2].`                                                                                                                                                                              |
-| `varm`                 | `SOMACollection[string, SOMASparseNDArray\|SOMADenseNDArray]` | A collection of dense matrices containing annotations of each _var_ row. Has the same shape as `var`, and is indexed with `varid`.                                                                                                                                                                 |
-| `varp`                 | `SOMACollection[string, SOMASparseNDArray]`                   | A collection of sparse matrices containing pairwise annotations of each _var_ row. Indexed with `[varid_1, varid_2]`                                                                                                                                                                               |
-| `var_spatial_presence` | `SOMADataFrame`                                               | Join table that stores if a particular _variable_ is stored in a given `SOMAScene`. This dataframe is optional and may be omitted even if the `SOMAExperiment` the `SOMAMeasurement` is in contains multiple `SOMAScene` items.                                                                    |
+| `var` | `SOMADataFrame` | Primary annotations on the _variable_ axis, for variables in this measurement (i.e., annotates columns of `X`). The contents of the `soma_joinid` pseudo-column define the _variable_ index domain, also known as `varid`. All variables for this measurement _must_ be defined in this dataframe. |
+| `X` | `SOMACollection[string, SOMASparseNDArray\|SOMADenseNDArray]` | A collection of matrices, each containing measured feature values. Each matrix is indexed by `[obsid, varid]`. Both sparse and dense 2D arrays are supported in `X`. |
+| `obsm` | `SOMACollection[string, SOMASparse\|SOMADenseNDArray]` | A collection of dense matrices containing annotations of each _obs_ row. Has the same shape as `obs`, and is indexed with `obsid`. |
+| `obsp` | `SOMACollection[string, SOMASparseNDArray]` | A collection of sparse matrices containing pairwise annotations of each _obs_ row. Indexed with `[obsid_1, obsid_2].` |
+| `varm` | `SOMACollection[string, SOMASparseNDArray\|SOMADenseNDArray]` | A collection of dense matrices containing annotations of each _var_ row. Has the same shape as `var`, and is indexed with `varid`. |
+| `varp` | `SOMACollection[string, SOMASparseNDArray]` | A collection of sparse matrices containing pairwise annotations of each _var_ row. Indexed with `[varid_1, varid_2]` |
+| `var_spatial_presence` | `SOMADataFrame` | Join table that stores if a particular _variable_ is stored in a given `SOMAScene`. This dataframe is optional and may be omitted even if the `SOMAExperiment` the `SOMAMeasurement` is in contains multiple `SOMAScene` items. |
 
 The `SOMAScene` is a sub-element of a `SOMAExperiment`, and is otherwise a specialized `SOMACollection` with pre-defined fields:
 
-| Field name | Field type                                                                                    | Field description                                                                                                                                                                                                                     |
+| Field name | Field type | Field description |
 | ---------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `obsl`     | `SOMACollection[string, SOMAPointCloudDataFrame\|SOMAGeometryDataFrame]`                      | Location-based annotations on the _observable_ domain. The `soma_joinid` in any item in this collection should be interpreted as the `obsid`                                                                                          |
-| `varl`     | `SOMACollection[string, SOMACollection[str, SOMAPointCloudDataFrame\|SOMAGeometryDataFrame]]` | Location-based annotations on the _variable_ domain. The outer collection is keyed on the measurement names. The `soma_joinid` for items in the inner collection should be interpreted as the `varid` for the respective measurement. |
-| `img`      | `SOMACollection[string, MultiscaleImage]`                                                     | A collection of multiscale images related to the experiment.                                                                                                                                                                          |
+| `obsl` | `SOMACollection[string, SOMAPointCloudDataFrame\|SOMAGeometryDataFrame]` | Location-based annotations on the _observable_ domain. The `soma_joinid` in any item in this collection should be interpreted as the `obsid` |
+| `varl` | `SOMACollection[string, SOMACollection[str, SOMAPointCloudDataFrame\|SOMAGeometryDataFrame]]` | Location-based annotations on the _variable_ domain. The outer collection is keyed on the measurement names. The `soma_joinid` for items in the inner collection should be interpreted as the `varid` for the respective measurement. |
+| `img` | `SOMACollection[string, MultiscaleImage]` | A collection of multiscale images related to the experiment. |
 
 For the entire `SOMAExperiment`, the index domain for the elements within `obsp`, `obsm` and `X` (first dimension) are the values defined by the `obs` dataframe `soma_joinid` column. For each `SOMAMeasurement`, the index domain for `varp`, `varm` and `X` (second dimension) are the values defined by the `var` dataframe `soma_joinid` column in the same measurement. In other words, all predefined fields in the `SOMAMeasurement` share a common `obsid` and `varid` domain, which is defined by the contents of the respective columns in `obs` and `var` dataframes.
 
@@ -338,21 +338,21 @@ As with other `SOMACollections`, the `SOMAExperiment`, `SOMAMeasurement`, and `S
 
 The following naming and indexing constraints are defined for the `SOMAExperiment` and `SOMAMeasurement`:
 
-| Field name                                     | Field constraints                                                                                                                                                        |
+| Field name | Field constraints |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `obs`, `var`                                   | Field type is a `SOMADataFrame`.                                                                                                                                         |
-| `ms`                                           | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMAMeasurement`.                                                              |
-| `spatial`                                      | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMAScene`.                                                                    |
-| `X`                                            | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMADenseNDArray` or `SOMASparseNDArray`.                                      |
-| `obsp`, `varp`                                 | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMASparseNDArray`.                                                            |
-| `obsm`, `varm`                                 | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMADenseNDArray`.                                                             |
-| `obsm`, `obsp`, `varm`, `varp`                 | Fields may be empty collections.                                                                                                                                         |
-| `X` collection values                          | All matrixes must have the shape `(O, V)`, where `O` is the domain of `obs.soma_joinid`, and `V` is the domain of `var.soma_joinid` in the containing `SOMAMeasurement`. |
-| `obsm` collection values                       | All matrixes must have the shape `(O, M)`, where `M` is user-defined. The domain of the first dimension is the values of `obs.soma_joinid`.                              |
-| `obsp` collection values                       | All matrixes must have the shape `(O, O)`. The domain of both dimensions is the values of `obs.soma_joinid`.                                                             |
-| `varm` collection values                       | All matrixes must have the shape `(V, M)`, where `M` is user-defined. The domain of the first dimension is the values of `var.soma_joinid`.                              |
-| `varp` collection values                       | All matrixes must have the shape `(V, V)`. The domain of both dimensions is the values of `var.soma_joinid`.                                                             |
-| `obs_spatial_presence`, `var_spatial_presence` | Field type is a `SOMADataFrame`. Index columns are `soma_joinid` and a string column named `scene_id` with exactly one other boolean column named `data`.                |
+| `obs`, `var` | Field type is a `SOMADataFrame`. |
+| `ms` | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMAMeasurement`. |
+| `spatial` | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMAScene`. |
+| `X` | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMADenseNDArray` or `SOMASparseNDArray`. |
+| `obsp`, `varp` | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMASparseNDArray`. |
+| `obsm`, `varm` | Field type is a `SOMACollection`, and each element in the collection has a value of type `SOMADenseNDArray`. |
+| `obsm`, `obsp`, `varm`, `varp` | Fields may be empty collections. |
+| `X` collection values | All matrixes must have the shape `(O, V)`, where `O` is the domain of `obs.soma_joinid`, and `V` is the domain of `var.soma_joinid` in the containing `SOMAMeasurement`. |
+| `obsm` collection values | All matrixes must have the shape `(O, M)`, where `M` is user-defined. The domain of the first dimension is the values of `obs.soma_joinid`. |
+| `obsp` collection values | All matrixes must have the shape `(O, O)`. The domain of both dimensions is the values of `obs.soma_joinid`. |
+| `varm` collection values | All matrixes must have the shape `(V, M)`, where `M` is user-defined. The domain of the first dimension is the values of `var.soma_joinid`. |
+| `varp` collection values | All matrixes must have the shape `(V, V)`. The domain of both dimensions is the values of `var.soma_joinid`. |
+| `obs_spatial_presence`, `var_spatial_presence` | Field type is a `SOMADataFrame`. Index columns are `soma_joinid` and a string column named `scene_id` with exactly one other boolean column named `data`. |
 
 # Functional Operations
 
@@ -395,11 +395,11 @@ When a SOMA object is opened for writing, write operations are not guaranteed to
 
 The common SOMA lifecycle operations are as follows:
 
-| Operation                      | Description                                                                                                  |
+| Operation | Description |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| static open(string uri, ...)   | Opens the SOMA object (of the type it is attached to).                                                       |
+| static open(string uri, ...) | Opens the SOMA object (of the type it is attached to). |
 | static create(string uri, ...) | Creates a new SOMA object (of the given type) at the given URI, and returns that object, opened for writing. |
-| close()                        | Closes the SOMA object, flushing all unsaved data.                                                           |
+| close() | Closes the SOMA object, flushing all unsaved data. |
 
 The exact mechanism by which these "static" methods are exposed may vary by language.
 For instance, in Python, `@classmethod`s are used, while in a language without class methods, the methods can be implemented as global-level functions:
@@ -496,12 +496,12 @@ Collections have additional closing-related semantics, described in [`SOMACollec
 
 All SOMA objects share the following common operations, in addition to the type-specific operations specified in each type's section:
 
-| Operation                      | Description                                                                                          |
+| Operation | Description |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| get metadata                   | Accesses the metadata as a mutable [`SOMAMetadataMapping`](#somametadatamapping).                    |
-| get context                    | Gets an implementation-specific [context value](#long-lived-context-data) for the given SOMA object. |
-| get soma_type                  | Returns a constant string describing the type of the object.                                         |
-| static exists(string uri, ...) | Tells if there is a SOMA object of the given type at the URI.                                        |
+| get metadata | Accesses the metadata as a mutable [`SOMAMetadataMapping`](#somametadatamapping). |
+| get context | Gets an implementation-specific [context value](#long-lived-context-data) for the given SOMA object. |
+| get soma_type | Returns a constant string describing the type of the object. |
+| static exists(string uri, ...) | Tells if there is a SOMA object of the given type at the URI. |
 
 ### Operation: exists
 
@@ -528,25 +528,25 @@ soma_impl.Collection.exists("backend://host/nonexistent/path")
 
 Summary of operations on a `SOMACollection`, where `ValueType` is any SOMA-defined foundational or composed type, including `SOMACollection`, `SOMADataFrame`, `SOMAPointCloudDataFrame`, `SOMAGeometryDataFrame`, `SOMADenseNDArray`, `SOMASparseNDArray`, `SOMAMultiscaleImage`, `SOMAExperiment`, `SOMAMeasurement`, or `SOMAScene`:
 
-| Operation     | Description                                                                |
+| Operation | Description |
 | ------------- | -------------------------------------------------------------------------- |
-| close()       | Closes this `SOMACollection` and other objects whose lifecycle it manages. |
-| get soma_type | Returns the constant "SOMACollection".                                     |
+| close() | Closes this `SOMACollection` and other objects whose lifecycle it manages. |
+| get soma_type | Returns the constant "SOMACollection". |
 
 In addition, `SOMACollection` supports operations to manage the contents of the collection:
 
-| Operation                                           | Description                                                                               |
+| Operation | Description |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| get(string key)                                     | Gets the object associated with the key.                                                  |
-| has(string key)                                     | Tests for the existence of key in collection.                                             |
-| iterator                                            | Iterates over the collection.                                                             |
-| get length                                          | Gets the number of elements in the collection.                                            |
-| set(string key, SOMAObject value, use_relative_uri) | Sets the key/value in the collection.                                                     |
-| del(string key)                                     | Removes the key/value from the collection. Does not delete the underlying object (value). |
-| add_new_collection(string key, ...)                 | Creates a new sub-Collection and adds it to this `SOMACollection`.                        |
-| add_new_dataframe(string key, ...)                  | Creates a new `DataFrame` and adds it to this `SOMACollection`.                           |
-| add_new_dense_ndarray(string key, ...)              | Creates a new `DenseNDArray` and adds it to this `SOMACollection`.                        |
-| add_new_sparse_ndarray(string key, ...)             | Creates a new `SparseNDArray` and adds it to this `SOMACollection`.                       |
+| get(string key) | Gets the object associated with the key. |
+| has(string key) | Tests for the existence of key in collection. |
+| iterator | Iterates over the collection. |
+| get length | Gets the number of elements in the collection. |
+| set(string key, SOMAObject value, use_relative_uri) | Sets the key/value in the collection. |
+| del(string key) | Removes the key/value from the collection. Does not delete the underlying object (value). |
+| add_new_collection(string key, ...) | Creates a new sub-Collection and adds it to this `SOMACollection`. |
+| add_new_dataframe(string key, ...) | Creates a new `DataFrame` and adds it to this `SOMACollection`. |
+| add_new_dense_ndarray(string key, ...) | Creates a new `DenseNDArray` and adds it to this `SOMACollection`. |
+| add_new_sparse_ndarray(string key, ...) | Creates a new `SparseNDArray` and adds it to this `SOMACollection`. |
 
 A `SOMACollection` also manages the lifecycle of objects directly instantiated by it.
 Objects accessed via getting a collection element, or objects created with one of the <code>add_new\_<var>object_type</var></code> methods are considered "owned" by the collection.
@@ -654,15 +654,15 @@ add_new_collection(string key, CollectionType kind, string uri = "", PlatformCon
 
 Summary of operations:
 
-| Operation                                | Description                                           |
+| Operation | Description |
 | ---------------------------------------- | ----------------------------------------------------- |
-| static create(uri, ...) -> SOMADataFrame | Create a `SOMADataFrame`.                             |
-| get soma_type                            | Returns the constant "SOMADataFrame".                 |
-| get schema -> Arrow.Schema               | Return data schema, in the form of an Arrow `Schema`. |
-| get index_column_names -> [string, ...]  | Return index (dimension) column names.                |
-| get count -> int                         | Return the number of rows in the `SOMADataFrame`.     |
-| read                                     | Read a subset of data from the `SOMADataFrame`.       |
-| write                                    | Write a subset of data to the `SOMADataFrame`.        |
+| static create(uri, ...) -> SOMADataFrame | Create a `SOMADataFrame`. |
+| get soma_type | Returns the constant "SOMADataFrame". |
+| get schema -> Arrow.Schema | Return data schema, in the form of an Arrow `Schema`. |
+| get index_column_names -> [string, ...] | Return index (dimension) column names. |
+| get count -> int | Return the number of rows in the `SOMADataFrame`. |
+| read | Read a subset of data from the `SOMADataFrame`. |
+| write | Write a subset of data to the `SOMADataFrame`. |
 
 A `SOMADataFrame` is indexed by one or more dataframe columns (also known as "dimensions"). The name and order of dimensions is specified at the time of creation. [Slices](#indexing-and-slicing) are addressable by the user-specified dimensions. The `soma_joinid` column may be specified as an index column.
 
@@ -754,16 +754,16 @@ All columns, including index columns and `soma_joinid` must be specified in the 
 
 Summary of operations:
 
-| Operation                                   | Description                                                      |
+| Operation | Description |
 | ------------------------------------------- | ---------------------------------------------------------------- |
-| static create(uri, ...) -> SOMADenseNDArray | Create a `SOMADenseNDArray` named with the URI.                  |
-| get soma_type                               | Returns the constant "SOMADenseNDArray".                         |
-| get shape -> (int, ...)                     | Return length of each dimension, always a list of length `ndim`. |
-| get ndim -> int                             | Return number of dimensions.                                     |
-| get schema -> Arrow.Schema                  | Return data schema, in the form of an Arrow Schema.              |
-| get is_sparse -> False                      | Return the constant False.                                       |
-| read                                        | Read a subarray from the `SOMADenseNDArray`.                     |
-| write                                       | Write a subarray to the `SOMADenseNDArray`.                      |
+| static create(uri, ...) -> SOMADenseNDArray | Create a `SOMADenseNDArray` named with the URI. |
+| get soma_type | Returns the constant "SOMADenseNDArray". |
+| get shape -> (int, ...) | Return length of each dimension, always a list of length `ndim`. |
+| get ndim -> int | Return number of dimensions. |
+| get schema -> Arrow.Schema | Return data schema, in the form of an Arrow Schema. |
+| get is_sparse -> False | Return the constant False. |
+| read | Read a subarray from the `SOMADenseNDArray`. |
+| write | Write a subarray to the `SOMADenseNDArray`. |
 
 ### Operation: create()
 
@@ -837,17 +837,17 @@ Parameters:
 
 Summary of operations:
 
-| Operation                                    | Description                                                             |
+| Operation | Description |
 | -------------------------------------------- | ----------------------------------------------------------------------- |
-| static create(uri, ...) -> SOMASparseNDArray | Create a `SOMASparseNDArray` named with the URI.                        |
-| get soma_type                                | Returns the constant "SOMASparseNDArray".                               |
-| get shape -> (int, ...)                      | Return length of each dimension, always a list of length `ndim`.        |
-| get ndim -> int                              | Return number of dimensions.                                            |
-| get schema -> Arrow.Schema                   | Return data schema, in the form of an Arrow `Schema`.                   |
-| get is_sparse -> True                        | Return the constant True.                                               |
-| get nnz -> uint                              | Return the number stored values in the array, including explicit zeros. |
-| read                                         | Read a slice of data from the `SOMASparseNDArray`.                      |
-| write                                        | Write a slice of data to the `SOMASparseNDArray`.                       |
+| static create(uri, ...) -> SOMASparseNDArray | Create a `SOMASparseNDArray` named with the URI. |
+| get soma_type | Returns the constant "SOMASparseNDArray". |
+| get shape -> (int, ...) | Return length of each dimension, always a list of length `ndim`. |
+| get ndim -> int | Return number of dimensions. |
+| get schema -> Arrow.Schema | Return data schema, in the form of an Arrow `Schema`. |
+| get is_sparse -> True | Return the constant True. |
+| get nnz -> uint | Return the number stored values in the array, including explicit zeros. |
+| read | Read a slice of data from the `SOMASparseNDArray`. |
+| write | Write a slice of data to the `SOMASparseNDArray`. |
 
 ### Operation: create()
 
@@ -931,10 +931,10 @@ Some functions accept enumerated values as parameters. Language-specific impleme
 
 The mode used to open a SOMA object from storage, defining the operations that can be performed.
 
-| Entry   | Description                                                                   |
+| Entry | Description |
 | ------- | ----------------------------------------------------------------------------- |
-| `read`  | The default opening mode. The caller can read from the object, but not write. |
-| `write` | The caller can write to the object, but not read.                             |
+| `read` | The default opening mode. The caller can read from the object, but not write. |
+| `write` | The caller can write to the object, but not read. |
 
 In the Python implementation, this uses the string constants `'r'` and `'w'`.
 
@@ -944,21 +944,21 @@ For more details about the semantics of read and write mode, see the [object lif
 
 The order that values will be returned from a read operation.
 
-| Entry          | Description                                                                        |
+| Entry | Description |
 | -------------- | ---------------------------------------------------------------------------------- |
-| `auto`         | The caller does not care about result order. Results can be returned in any order. |
-| `row-major`    | The results are returned in row-major order.                                       |
-| `column-major` | The results are returned in column-major order.                                    |
+| `auto` | The caller does not care about result order. Results can be returned in any order. |
+| `row-major` | The results are returned in row-major order. |
+| `column-major` | The results are returned in column-major order. |
 
 ### URIType
 
 How the URI of a new element should be stored by a collection.
 
-| Entry      | Description                                                          |
+| Entry | Description |
 | ---------- | -------------------------------------------------------------------- |
-| `auto`     | The collection will determine what type of URI to use automatically. |
-| `absolute` | The collection will always use an absolute URI to store the entry.   |
-| `relative` | The collection will always use a relative URI to store the entry.    |
+| `auto` | The collection will determine what type of URI to use automatically. |
+| `absolute` | The collection will always use an absolute URI to store the entry. |
+| `relative` | The collection will always use a relative URI to store the entry. |
 
 In the Python implementation, this is represented with a `use_relative_uri` parameter to the given method, where `None` (the default) represents `auto`, `False` represents `absolute`, and `True` represents `relative`.
 
@@ -974,14 +974,14 @@ The `SOMAMetadataMapping` is an interface to a string-keyed mutable map, represe
 
 The following operations will exist to manipulate the mapping, providing a getter/setter interface plus the ability to iterate on the collection:
 
-| Operation                      | Description                                            |
+| Operation | Description |
 | ------------------------------ | ------------------------------------------------------ |
-| get(string key) -> value       | Get the value associated with the key.                 |
-| has(string key) -> bool        | Test for key existence.                                |
-| set(string key, value) -> void | Set the value associated with the key.                 |
-| del(string key) -> void        | Remove the key/value from the collection.              |
-| iterator                       | Iterate over the collection.                           |
-| get length                     | Get the length of the map, the number of keys present. |
+| get(string key) -> value | Get the value associated with the key. |
+| has(string key) -> bool | Test for key existence. |
+| set(string key, value) -> void | Set the value associated with the key. |
+| del(string key) -> void | Remove the key/value from the collection. |
+| iterator | Iterate over the collection. |
+| get length | Get the length of the map, the number of keys present. |
 
 > ℹ️ **Note**: it is possible that the data model will grow to include more complex value types. If possible, retain that future option in any API defined.
 
@@ -989,30 +989,30 @@ The following operations will exist to manipulate the mapping, providing a gette
 
 Read operations on foundational types return an iterator over "batches" of data, enabling the processing of larger-than-core datasets. The `SOMABatchSize` allows user control over read batch size, and accepts the following methods of determining batch size:
 
-| BatchSize type | Description                                                                                                                                           |
+| BatchSize type | Description |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `count`        | Batch size defined by result count. For a SOMADataFrame this indicates row count returned per `Arrow.Table`, or for an ND array the number of values. |
-| `size`         | Partition defined by size, in bytes, e.g., max `Arrow.Table` size returned by `SOMADataFRame` read operation.                                         |
-| `auto`         | An automatically determined, "reasonable" default partition size. This is the default batch size.                                                     |
+| `count` | Batch size defined by result count. For a SOMADataFrame this indicates row count returned per `Arrow.Table`, or for an ND array the number of values. |
+| `size` | Partition defined by size, in bytes, e.g., max `Arrow.Table` size returned by `SOMADataFRame` read operation. |
+| `auto` | An automatically determined, "reasonable" default partition size. This is the default batch size. |
 
 ### SOMAReadPartitions
 
 To facilitate distributed computation, read operations on foundational types accept a user-specified parameter indicating the desired partitioning of reads and which partition any given read should return. The following options are supported:
 
-| Partition Type | Description                                                                                                                                                                        |
+| Partition Type | Description |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `IofN`         | Given I and N, read operations will return the Ith partition of N approximately equal size partitions. Partition boundaries will be stable for any given N and array or dataframe. |
+| `IofN` | Given I and N, read operations will return the Ith partition of N approximately equal size partitions. Partition boundaries will be stable for any given N and array or dataframe. |
 
 ### SOMASparseNDArrayRead
 
 `SparseNDArray` `read` operations can return results in a variety of formats. The `SOMASparseNDArrayRead` type is an intermediate result type that allows the client to choose the encoding format that will be used to return the result data.
 
-| Format         | Description                                                                                   |
+| Format | Description |
 | -------------- | --------------------------------------------------------------------------------------------- |
-| `dense`        | Return an iterator of `Arrow Tensor`s containing slice values.                                |
-| `coos`         | Return an iterator of `Arrow.SparseCOOTensor`s containing COO-encoded coordinates and values. |
-| `record-batch` | Return an iterator `Arrow.RecordBatch` containing COO-encoded coordinates and values.         |
-| `table`        | Return an iterator of `Arrow.Table`s containing COO-encoded coordinates and values.           |
+| `dense` | Return an iterator of `Arrow Tensor`s containing slice values. |
+| `coos` | Return an iterator of `Arrow.SparseCOOTensor`s containing COO-encoded coordinates and values. |
+| `record-batch` | Return an iterator `Arrow.RecordBatch` containing COO-encoded coordinates and values. |
+| `table` | Return an iterator of `Arrow.Table`s containing COO-encoded coordinates and values. |
 
 ## General Utilities
 
@@ -1220,57 +1220,57 @@ However, client code should treat the `context` object on any instantiated SOMA 
 # Changelog
 
 1. Acceptance of Arrow as base type system.
-2. Adding explicit separation of foundational and composed types, and clarified the intent of composed types.
-3. Rename `uns` to `metadata`.
-4. Added initial prose for value filter expressions.
-5. Added further clarification to read incremental return.
-6. SOMAMatrix removed.
-7. Operations clarified (add description). Remove assumption of handle/object state.
-8. SOMADataFrame generalized to row-indexed or (multi-) user-indexed. Adding \_\_rowid pseudo-column to use in indexing dense matrices.
-9. Introduced SOMADenseNdArray/SOMAsparseNdArray and SOMAExperiment/SOMAMeasurement.
-10. Removed composed type `SOMA`.
-11. Added initial general utility operations.
-12. Clarified the data types that may be stored in `metadata`.
-13. Clarified namespacing of reserved slots in SOMAExperiment/SOMAMeasurement.
-14. Renamed SOMAMapping to SOMAMetadataMapping to clarify use.
-15. Add read partitions and ordering to foundational types.
-16. Clarify ABI for read/write chunks to NDArrays.
-17. Removed open issues around `raw` - there is already sufficient expressiveness in this spec.
-18. Removed var_ms/obs_ms.
-19. Editorial cleanup and clarifications.
-20. Simplified dataframe indexing to indexed/non-indexed. Removed from data model; isolated to only those operations affected.
-21. Add parameter for storage-engine-specific config, to read/write/create ops.
-22. Support both sparse and dense ndarray in SOMAExperiment X slot.
-23. Split read batch_size and partitioning, and clarify intent.
-24. Allow multiple format support for NDArray read/write ops.
-25. Clarified SOMACollection delete semantics.
-26. \_\_rowid changed to soma_rowid. Use `soma` and `SOMA` as "reserved" prefixes.
-27. Various editorial clarifications.
-28. Clarify distinction between soma_rowid pseudo-column and soma_joinid column.
-29. Split indexed/non-indexed dataframe into two types to clarify differing indexing/slicing semantics, and the existence of the soma_rowid pseudo-column only in non-indexed dataframes.
-30. Most use of Arrow RecordBatch updated to be a Table, as this allows for chunked arrays (larger objects).
-31. Clarify that read operations can accept a "list of scalar" in the form of an Arrow Array or ChunkedArray.
-32. Clarify the return value of `get schema` operation for NdArray types.
-33. Clarified the function name returning the SOMA API version (`get_SOMA_version`), and bumped API version to `0.2.0-dev`.
-34. All offset types (soma_rowid, soma_joinid) changed from uint64 to positive int64.
-35. Remove `reshape` operation from the NdArray types.
-36. Clarify type conformance and promotion.
-37. NdArray COO column names - add `soma` prefix to move all names into the reserved namespace.
-38. Clarify explicit nature of soma_rowid/soma_joinid handling throughout.
-39. Renamed `type` fields to `soma_type`.
-40. Remove SOMADataFrame; rename `SOMAIndexedDataFrame` to `SOMADataFrame`.
-41. Add description of `platform_config` objects.
-42. Change `NdArray` to `NDArray`.
-43. Add `context` field.
-44. Pull description of common operations into its own section.
-45. Specify object lifecycle and related operations (`create`, `open`, `add_new_*`, etc.).
-46. Uniformize backticks, punctuation, etc.
-47. Fixed erroneous backticks, spelling, and capitalization.
-48. Renamed `SOMADataFrame.read()` `ids` param and `SOMASparseNDArray.read()` `slice` param to `coords`, for consistency between `SOMADataFrame`, `SOMASparseNDArray` and `SOMADenseNDArray` types.
-49. Updated `SOMABatchFormat` section, renaming to `SOMASparseNDArrayRead` and removing the `csr`, `csc`, and `record-batch` format options.
-50. Removed `SOMASparseNDArray.read()` `batch_format` param and changed return type to `SOMASparseNDArrayRead`.
-51. Renamed `Collection.add_new_collection()` `type` param to `kind`.
-52. Removed ⚠️-marked commentary.
-53. Added `SOMAMeasurement` to "Data Model" section, under "composed types".
-54. Allowed all N-d arrays to be sparse.
-55. Added new datatypes `SOMAScene`, `SOMAPointCloudDataFrame`, `SOMAGeometryDataframe`, and `SOMAMultiscaleImage`, and bumped the API version to `0.3.0-dev`.
+1. Adding explicit separation of foundational and composed types, and clarified the intent of composed types.
+1. Rename `uns` to `metadata`.
+1. Added initial prose for value filter expressions.
+1. Added further clarification to read incremental return.
+1. SOMAMatrix removed.
+1. Operations clarified (add description). Remove assumption of handle/object state.
+1. SOMADataFrame generalized to row-indexed or (multi-) user-indexed. Adding \_\_rowid pseudo-column to use in indexing dense matrices.
+1. Introduced SOMADenseNdArray/SOMAsparseNdArray and SOMAExperiment/SOMAMeasurement.
+1. Removed composed type `SOMA`.
+1. Added initial general utility operations.
+1. Clarified the data types that may be stored in `metadata`.
+1. Clarified namespacing of reserved slots in SOMAExperiment/SOMAMeasurement.
+1. Renamed SOMAMapping to SOMAMetadataMapping to clarify use.
+1. Add read partitions and ordering to foundational types.
+1. Clarify ABI for read/write chunks to NDArrays.
+1. Removed open issues around `raw` - there is already sufficient expressiveness in this spec.
+1. Removed var_ms/obs_ms.
+1. Editorial cleanup and clarifications.
+1. Simplified dataframe indexing to indexed/non-indexed. Removed from data model; isolated to only those operations affected.
+1. Add parameter for storage-engine-specific config, to read/write/create ops.
+1. Support both sparse and dense ndarray in SOMAExperiment X slot.
+1. Split read batch_size and partitioning, and clarify intent.
+1. Allow multiple format support for NDArray read/write ops.
+1. Clarified SOMACollection delete semantics.
+1. \_\_rowid changed to soma_rowid. Use `soma` and `SOMA` as "reserved" prefixes.
+1. Various editorial clarifications.
+1. Clarify distinction between soma_rowid pseudo-column and soma_joinid column.
+1. Split indexed/non-indexed dataframe into two types to clarify differing indexing/slicing semantics, and the existence of the soma_rowid pseudo-column only in non-indexed dataframes.
+1. Most use of Arrow RecordBatch updated to be a Table, as this allows for chunked arrays (larger objects).
+1. Clarify that read operations can accept a "list of scalar" in the form of an Arrow Array or ChunkedArray.
+1. Clarify the return value of `get schema` operation for NdArray types.
+1. Clarified the function name returning the SOMA API version (`get_SOMA_version`), and bumped API version to `0.2.0-dev`.
+1. All offset types (soma_rowid, soma_joinid) changed from uint64 to positive int64.
+1. Remove `reshape` operation from the NdArray types.
+1. Clarify type conformance and promotion.
+1. NdArray COO column names - add `soma` prefix to move all names into the reserved namespace.
+1. Clarify explicit nature of soma_rowid/soma_joinid handling throughout.
+1. Renamed `type` fields to `soma_type`.
+1. Remove SOMADataFrame; rename `SOMAIndexedDataFrame` to `SOMADataFrame`.
+1. Add description of `platform_config` objects.
+1. Change `NdArray` to `NDArray`.
+1. Add `context` field.
+1. Pull description of common operations into its own section.
+1. Specify object lifecycle and related operations (`create`, `open`, `add_new_*`, etc.).
+1. Uniformize backticks, punctuation, etc.
+1. Fixed erroneous backticks, spelling, and capitalization.
+1. Renamed `SOMADataFrame.read()` `ids` param and `SOMASparseNDArray.read()` `slice` param to `coords`, for consistency between `SOMADataFrame`, `SOMASparseNDArray` and `SOMADenseNDArray` types.
+1. Updated `SOMABatchFormat` section, renaming to `SOMASparseNDArrayRead` and removing the `csr`, `csc`, and `record-batch` format options.
+1. Removed `SOMASparseNDArray.read()` `batch_format` param and changed return type to `SOMASparseNDArrayRead`.
+1. Renamed `Collection.add_new_collection()` `type` param to `kind`.
+1. Removed ⚠️-marked commentary.
+1. Added `SOMAMeasurement` to "Data Model" section, under "composed types".
+1. Allowed all N-d arrays to be sparse.
+1. Added new datatypes `SOMAScene`, `SOMAPointCloudDataFrame`, `SOMAGeometryDataframe`, and `SOMAMultiscaleImage`, and bumped the API version to `0.3.0-dev`.


### PR DESCRIPTION
Changes:
1. Add pre-commit action for markdown files  using `mdformat`
2. Remove `prettier` pre-commit action
3. Run pre-commit autoupdate to update repo versions
4. Run the pre-commit, which reformatted MD files